### PR TITLE
fix: -S flag breaks on submodule names containing spaces (issue #157)

### DIFF
--- a/bin/hug
+++ b/bin/hug
@@ -3,11 +3,211 @@
 # Main dispatcher - detects repository type and delegates to appropriate SCM
 
 # Set HUG_HOME if not already set (fallback derivation)
+# WHY: HUG_HOME must be frozen BEFORE any cd, so library lookups remain correct
+# even after -C or -S changes the working directory.
 if [[ -z "${HUG_HOME:-}" ]]; then
   script_dir="$(cd "$(dirname "$0")" && pwd)"
   HUG_HOME="$(cd "$script_dir/../.." && pwd)"
 fi
 export HUG_HOME
+
+# ── Global flag parsing loop ──────────────────────────────────────────────────
+# WHY: Hug supports global flags (-C <path>, -S <submodule>, --submodule=<name>)
+# that must be consumed BEFORE the command name reaches the case statement or
+# SCM detection. This loop peels off global flags, leaving $1 = the command.
+#
+# DESIGN: Uses `cd` rather than `exec git -C` so that:
+#   1. SCM detection (git rev-parse / hg root) inspects the TARGET dir
+#   2. clone/init/help dispatch works from the cd'd directory
+#   3. No -C threading needed into the final exec calls
+#
+# SAFETY: Unknown flags (e.g., -p for git) fall through to `break` because they
+# aren't `-C`/`-S`/`--submodule`, so they remain in $@ for the command to handle.
+# Command names are never `-`-prefixed, so they also break correctly.
+# ────────────────────────────────────────────────────────────────────────────────
+
+while (($#)); do
+  case "$1" in
+  # -C <path>: change to directory before dispatching (mirrors git -C)
+  # This is SCM-agnostic: works for git, hg, clone, init, help.
+  -C)
+    # Guard: require an argument (prevents unbound $2 under set -u)
+    if [[ -z "${2:-}" ]]; then
+      echo "hug: -C requires a path argument" >&2
+      exit 1
+    fi
+    # Precheck: must be a directory (cd into a file would succeed but is wrong)
+    if [[ ! -d "$2" ]]; then
+      echo "hug: -C: not a directory: $2" >&2
+      exit 1
+    fi
+    # Use cd -- to handle paths starting with '-' (e.g., hug -C -weird-dir)
+    cd -- "$2" || exit 1
+    shift 2
+    ;;
+
+  # -S <name|path>: resolve and cd into a git submodule
+  # --submodule=<name|path>: long form (same resolution logic)
+  -S | --submodule=*)
+    local_submodule_arg=""
+    if [[ "$1" == "-S" ]]; then
+      # Short form: -S <name>
+      if [[ -z "${2:-}" ]]; then
+        echo "hug: -S requires a submodule name or path" >&2
+        exit 1
+      fi
+      local_submodule_arg="$2"
+      shift
+    else
+      # Long form: --submodule=<name>
+      local_submodule_arg="${1#--submodule=}"
+      if [[ -z "$local_submodule_arg" ]]; then
+        echo "hug: --submodule= requires a submodule name or path" >&2
+        exit 1
+      fi
+    fi
+    shift # consume the -S or --submodule=<name>
+
+    # ── Submodule resolution ──────────────────────────────────────────────
+    # Submodules are git-only. Detect hg repos early with a clear error.
+    # WHY git config --file: parses .gitmodules safely (handles spaces,
+    # quoting) unlike grep/awk approaches. Requires a git repo at CWD.
+    if ! git rev-parse --git-dir > /dev/null 2>&1; then
+      if hg root > /dev/null 2>&1; then
+        echo "hug: -S: submodules are not supported in Mercurial repositories" >&2
+      else
+        echo "hug: -S: not in a Git repository (needed to resolve submodule '$local_submodule_arg')" >&2
+      fi
+      exit 1
+    fi
+
+    local_top_level="$(git rev-parse --show-toplevel)" || {
+      echo "hug: -S: cannot determine repository root" >&2
+      exit 1
+    }
+
+    local_modules_file="$local_top_level/.gitmodules"
+    if [[ ! -f "$local_modules_file" ]]; then
+      echo "hug: -S: no submodules configured (.gitmodules not found)" >&2
+      exit 1
+    fi
+
+    # Parse all submodule entries from .gitmodules.
+    # Output format per entry: "submodule.<name>.path <path_value>"
+    # git config --file handles quoting, spaces, and special characters safely.
+    # WHY anchored regex '^submodule\..*\.path$': prevents false positives from
+    # URL keys (e.g. 'submodule.foo.url') that would match an unanchored pattern.
+    _sub_entries=()
+    while IFS= read -r line; do
+      _sub_entries+=("$line")
+    done < <(git config --file "$local_modules_file" --get-regexp '^submodule\..*\.path$')
+
+    if ((${#_sub_entries[@]} == 0)); then
+      echo "hug: -S: no submodules configured in .gitmodules" >&2
+      exit 1
+    fi
+
+    # Search: try exact name match first, then exact path match.
+    # Parsing is robust to submodule names containing ".path" — we split on the
+    # first space to get the config key, then strip known prefixes/suffixes.
+    local_resolved_path=""
+
+    for entry in "${_sub_entries[@]}"; do
+      # entry format: "submodule.<name>.path <path_value>"
+      # Split on first space to separate key from value — avoids fragile
+      # parameter expansion on ".path " which breaks for names containing ".path".
+      _entry_key="${entry%% *}"              # "submodule.<name>.path"
+      _entry_path="${entry#* }"              # "<path_value>"
+      _entry_name="${_entry_key#submodule.}" # "<name>.path"
+      _entry_name="${_entry_name%.path}"     # "<name>"
+
+      # Exact name match
+      if [[ "$_entry_name" == "$local_submodule_arg" ]]; then
+        if [[ -n "$local_resolved_path" && "$local_resolved_path" != "$_entry_path" ]]; then
+          echo "hug: -S: '$local_submodule_arg' is ambiguous (matches multiple submodules)" >&2
+          echo "Available submodules:" >&2
+          for e in "${_sub_entries[@]}"; do
+            _n="${e%% *}"
+            _n="${_n#submodule.}"
+            _n="${_n%.path}"
+            echo "  $_n" >&2
+          done
+          exit 1
+        fi
+        local_resolved_path="$_entry_path"
+      fi
+    done
+
+    # If no name match, try path match (user passed a relative path)
+    if [[ -z "$local_resolved_path" ]]; then
+      for entry in "${_sub_entries[@]}"; do
+        _entry_path="${entry#* }"
+        if [[ "$_entry_path" == "$local_submodule_arg" ]]; then
+          local_resolved_path="$_entry_path"
+          break
+        fi
+      done
+    fi
+
+    if [[ -z "$local_resolved_path" ]]; then
+      echo "hug: -S: submodule '$local_submodule_arg' not found" >&2
+      echo "Available submodules:" >&2
+      for entry in "${_sub_entries[@]}"; do
+        _n="${entry%% *}"
+        _n="${_n#submodule.}"
+        _n="${_n%.path}"
+        echo "  $_n" >&2
+      done
+      exit 1
+    fi
+
+    # Resolve relative to repo top-level, then canonicalize for containment check.
+    # WHY cd to top-level first: submodule paths in .gitmodules are relative
+    # to the repo root, not to CWD (which may have been changed by -C).
+    # WHY pwd -P: resolves symlinks so the prefix-based containment check cannot
+    # be bypassed by a symlink pointing outside the repository.
+    # WHY the || guard: if the submodule directory is missing (uninitialized and
+    # then rm'd), the cd inside $() fails silently — local_resolved_abs would be
+    # empty and the containment check would give a misleading error. We catch
+    # this early with the correct "not initialized" message instead.
+    local_resolved_abs="$(cd "$local_top_level" && cd -- "$local_resolved_path" 2> /dev/null && pwd -P)" || {
+      echo "hug: -S: submodule '$local_submodule_arg' is not initialized (directory missing)" >&2
+      echo "Run: git submodule update --init -- $local_resolved_path" >&2
+      exit 1
+    }
+
+    # Containment check: reject paths outside the repository
+    # WHY: prevents escape via symlinks, ../../../tricks, or absolute paths
+    local_top_level_canonical="$(cd "$local_top_level" && pwd -P)"
+    if [[ "$local_resolved_abs" != "$local_top_level_canonical"/* ]]; then
+      echo "hug: -S: path '$local_resolved_path' is outside the repository" >&2
+      exit 1
+    fi
+
+    # Check if submodule is initialized (directory exists with content)
+    if [[ ! -d "$local_resolved_abs" || -z "$(ls -A "$local_resolved_abs" 2> /dev/null)" ]]; then
+      echo "hug: -S: submodule '$local_submodule_arg' is not initialized" >&2
+      echo "Run: git submodule update --init -- $local_resolved_path" >&2
+      exit 1
+    fi
+
+    cd -- "$local_resolved_abs" || exit 1
+    ;;
+
+  # --: explicit end of global flags; pass remaining args to command
+  --)
+    shift
+    break
+    ;;
+
+  # Command name or unknown flag → stop consuming globals
+  # Unknown flags (like -f, --force, -p) fall through to the command.
+  # This is intentional: hug doesn't parse command-specific flags here.
+  *)
+    break
+    ;;
+  esac
+done
 
 # Handle commands that work outside repository
 case "${1:-}" in

--- a/bin/hug
+++ b/bin/hug
@@ -92,72 +92,48 @@ while (($#)); do
       exit 1
     fi
 
-    # Parse all submodule entries from .gitmodules.
-    # Output format per entry: "submodule.<name>.path <path_value>"
-    # git config --file handles quoting, spaces, and special characters safely.
-    # WHY anchored regex '^submodule\..*\.path$': prevents false positives from
-    # URL keys (e.g. 'submodule.foo.url') that would match an unanchored pattern.
-    _sub_entries=()
-    while IFS= read -r line; do
-      _sub_entries+=("$line")
-    done < <(git config --file "$local_modules_file" --get-regexp '^submodule\..*\.path$')
+    # Parse all submodule entries from .gitmodules using NUL-delimited output.
+    # git config --null --get-regexp outputs "key\nvalue\0" per entry.
+    # WHY --null: eliminates ambiguous space-based key/value splitting when
+    # submodule names or paths contain spaces (issue #157).
+    # WHY associative arrays: O(1) lookup replaces three O(N) loops, and the
+    # name-extraction logic (strip submodule. prefix + .path suffix) appears
+    # once instead of three separate times.
+    declare -A _sub_name_to_path
+    declare -A _sub_path_to_name
+    while IFS= read -r -d '' _entry; do
+      _entry_key="${_entry%%$'\n'*}"         # "submodule.<name>.path"
+      _entry_path="${_entry#*$'\n'}"         # "<path_value>"
+      _entry_name="${_entry_key#submodule.}" # "<name>.path"
+      _entry_name="${_entry_name%.path}"     # "<name>"
+      _sub_name_to_path["$_entry_name"]="$_entry_path"
+      _sub_path_to_name["$_entry_path"]="$_entry_name"
+    done < <(git config --file "$local_modules_file" --null --get-regexp '^submodule\..*\.path$')
 
-    if ((${#_sub_entries[@]} == 0)); then
+    if ((${#_sub_name_to_path[@]} == 0)); then
       echo "hug: -S: no submodules configured in .gitmodules" >&2
       exit 1
     fi
 
-    # Search: try exact name match first, then exact path match.
-    # Parsing is robust to submodule names containing ".path" — we split on the
-    # first space to get the config key, then strip known prefixes/suffixes.
-    local_resolved_path=""
+    # Resolve: try exact name match first, then exact path match.
+    # WHY associative arrays: O(1) lookup replaces O(N) scans.
+    local_resolved_path="${_sub_name_to_path[$local_submodule_arg]:-}"
 
-    for entry in "${_sub_entries[@]}"; do
-      # entry format: "submodule.<name>.path <path_value>"
-      # Split on first space to separate key from value — avoids fragile
-      # parameter expansion on ".path " which breaks for names containing ".path".
-      _entry_key="${entry%% *}"              # "submodule.<name>.path"
-      _entry_path="${entry#* }"              # "<path_value>"
-      _entry_name="${_entry_key#submodule.}" # "<name>.path"
-      _entry_name="${_entry_name%.path}"     # "<name>"
-
-      # Exact name match
-      if [[ "$_entry_name" == "$local_submodule_arg" ]]; then
-        if [[ -n "$local_resolved_path" && "$local_resolved_path" != "$_entry_path" ]]; then
-          echo "hug: -S: '$local_submodule_arg' is ambiguous (matches multiple submodules)" >&2
-          echo "Available submodules:" >&2
-          for e in "${_sub_entries[@]}"; do
-            _n="${e%% *}"
-            _n="${_n#submodule.}"
-            _n="${_n%.path}"
-            echo "  $_n" >&2
-          done
-          exit 1
-        fi
-        local_resolved_path="$_entry_path"
-      fi
-    done
-
-    # If no name match, try path match (user passed a relative path)
+    # If no name match, try exact path match (user passed a relative path)
     if [[ -z "$local_resolved_path" ]]; then
-      for entry in "${_sub_entries[@]}"; do
-        _entry_path="${entry#* }"
-        if [[ "$_entry_path" == "$local_submodule_arg" ]]; then
-          local_resolved_path="$_entry_path"
-          break
-        fi
-      done
+      if [[ -v _sub_path_to_name[$local_submodule_arg] ]]; then
+        local_resolved_path="$local_submodule_arg"
+      fi
     fi
 
     if [[ -z "$local_resolved_path" ]]; then
       echo "hug: -S: submodule '$local_submodule_arg' not found" >&2
       echo "Available submodules:" >&2
-      for entry in "${_sub_entries[@]}"; do
-        _n="${entry%% *}"
-        _n="${_n#submodule.}"
-        _n="${_n%.path}"
+      # WHY sort: deterministic output for tests and scripting, unlike
+      # the old config-file-order listing which varied by git version.
+      while IFS= read -r _n; do
         echo "  $_n" >&2
-      done
+      done < <(printf '%s\n' "${!_sub_name_to_path[@]}" | sort)
       exit 1
     fi
 

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1277,7 +1277,146 @@ cleanup_test_submodule_worktree() {
   rm -rf "$meta_repo" 2> /dev/null || true
 }
 
-# Create a test worktree with uncommitted changes
+# create_test_repo_with_submodule [name1 name2 ...]
+#
+# Creates a parent git repo with one or more submodules.  Each submodule is a
+# standalone git repo added as a local submodule, then initialized.
+#
+# Args:
+#   name1 name2 ...  Submodule directory names (default: "sub")
+#
+# Outputs (stdout): the parent repo path
+#
+# After calling, the following global variables are set:
+#   TEST_PARENT_REPO       — parent repo path (set IN ADDITION to stdout)
+#   TEST_SUBMODULE_NAMES   — bash array of submodule names (as given)
+#   TEST_SUBMODULE_PATHS   — bash array of absolute submodule checkout paths
+#   TEST_SUBMODULE_ORIGINS — bash array of origin repo paths (for cleanup)
+#
+# IMPORTANT — subshell gotcha: $() runs the function in a subshell, so
+# globals set inside will NOT propagate to the caller.  Tests that need the
+# global arrays must call the function directly (not via $() or `run`):
+#   create_test_repo_with_submodule sub1 sub2
+#   parent=$TEST_PARENT_REPO   # read the global instead of capturing stdout
+#
+# WHY global arrays instead of returning multiple values: Bash functions can
+# only return a single exit code and stdout string.  Tests commonly need all
+# four pieces (parent path, names for assertions, paths for file checks,
+# origins for cleanup), so globals are the pragmatic choice.  The stdout
+# print is kept for consistency with other helpers, but callers needing
+# globals MUST use TEST_PARENT_REPO instead of $().
+#
+# WHY `protocol.file.allow=always`: modern Git (CVE-2022-39253 hardening)
+# refuses local submodule URLs by default.  Tests that add local submodules
+# must opt in, otherwise `git submodule add` silently fails with an opaque
+# "repository does not exist" error.  See create_test_submodule_worktree
+# for the same hardening rationale.
+#
+# Requires: create_temp_repo_dir, git_commit_deterministic (from this file)
+create_test_repo_with_submodule() {
+  # Default to "sub" when no names provided
+  if [[ $# -eq 0 ]]; then
+    set -- "sub"
+  fi
+
+  local parent_repo
+  parent_repo=$(create_temp_repo_dir) || {
+    echo "create_test_repo_with_submodule: failed to create temp dir" >&2
+    return 1
+  }
+
+  # Initialize the parent repo with a first commit so submodules have a tree
+  # to attach to.  Without this, `git submodule add` fails because HEAD has
+  # no commits.
+  (
+    cd "$parent_repo" || exit 1
+    git init -q --initial-branch=main 2> /dev/null || git init -q
+    git config user.email "test@hug-scm.test"
+    git config user.name "Hug Test"
+    git symbolic-ref HEAD refs/heads/main 2> /dev/null || true
+    echo "parent" > parent.txt
+    git add parent.txt
+    git_commit_deterministic "Parent initial"
+  ) || {
+    echo "create_test_repo_with_submodule: failed to init parent repo at $parent_repo" >&2
+    rm -rf "$parent_repo" 2> /dev/null
+    return 1
+  }
+
+  # Reset global arrays — each call gets a clean slate even if a previous
+  # call left stale data.
+  TEST_SUBMODULE_NAMES=()
+  TEST_SUBMODULE_PATHS=()
+  TEST_SUBMODULE_ORIGINS=()
+
+  for name in "$@"; do
+    # Create a standalone origin repo for this submodule
+    local origin_repo
+    origin_repo=$(create_temp_repo_dir) || {
+      echo "create_test_repo_with_submodule: failed to create origin dir for '$name'" >&2
+      rm -rf "$parent_repo" "${TEST_SUBMODULE_ORIGINS[@]}" 2> /dev/null
+      return 1
+    }
+
+    (
+      cd "$origin_repo" || exit 1
+      git init -q --initial-branch=main 2> /dev/null || git init -q
+      git config user.email "test@hug-scm.test"
+      git config user.name "Hug Test"
+      git symbolic-ref HEAD refs/heads/main 2> /dev/null || true
+      echo "$name" > content.txt
+      git add content.txt
+      git_commit_deterministic "$name initial"
+    ) || {
+      echo "create_test_repo_with_submodule: failed to init origin repo '$name' at $origin_repo" >&2
+      rm -rf "$parent_repo" "$origin_repo" "${TEST_SUBMODULE_ORIGINS[@]}" 2> /dev/null
+      return 1
+    }
+
+    # Add the origin repo as a submodule in the parent.
+    # The `-c protocol.file.allow=always` is critical — without it, modern Git
+    # (post CVE-2022-39253) rejects file:// submodule URLs.
+    local _add_err
+    if ! _add_err=$(cd "$parent_repo" && git -c protocol.file.allow=always submodule add -q "$origin_repo" "$name" 2>&1); then
+      echo "create_test_repo_with_submodule: failed to add submodule '$name'" >&2
+      echo "  git stderr: $_add_err" >&2
+      rm -rf "$parent_repo" "$origin_repo" "${TEST_SUBMODULE_ORIGINS[@]}" 2> /dev/null
+      return 1
+    fi
+
+    # Commit the submodule addition (each submodule gets its own commit so
+    # tests can inspect `.gitmodules` incrementally if needed).
+    (
+      cd "$parent_repo" || exit 1
+      git_commit_deterministic "Add submodule $name"
+    ) || {
+      echo "create_test_repo_with_submodule: failed to commit submodule '$name'" >&2
+      rm -rf "$parent_repo" "$origin_repo" "${TEST_SUBMODULE_ORIGINS[@]}" 2> /dev/null
+      return 1
+    }
+
+    TEST_SUBMODULE_NAMES+=("$name")
+    TEST_SUBMODULE_PATHS+=("$parent_repo/$name")
+    TEST_SUBMODULE_ORIGINS+=("$origin_repo")
+  done
+
+  # Initialize all submodules so their working directories actually exist.
+  # `git submodule add` records the reference, but the checkout needs an
+  # explicit `update --init` to materialize files in the submodule dir.
+  (
+    cd "$parent_repo" || exit 1
+    git submodule update --init --recursive 2> /dev/null
+  ) || {
+    echo "create_test_repo_with_submodule: failed to initialize submodules" >&2
+    return 1
+  }
+
+  # Set global for callers that need the path AND the submodule arrays
+  # (since $() runs in a subshell and would lose the globals).
+  TEST_PARENT_REPO="$parent_repo"
+
+  printf '%s\n' "$parent_repo"
+}
 # Usage: worktree_path=$(create_test_worktree_with_changes "feature-branch" "/path/to/repo")
 create_test_worktree_with_changes() {
   local branch="$1"

--- a/tests/test_submodule_helper.bats
+++ b/tests/test_submodule_helper.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# Tests for create_test_repo_with_submodule test helper
+
+setup() {
+  load test_helper
+}
+
+# NOTE: We do NOT use `run` for these tests because `run` executes in a subshell,
+# which loses the global variables (TEST_SUBMODULE_NAMES, TEST_SUBMODULE_PATHS,
+# TEST_SUBMODULE_ORIGINS) that the function sets. Instead, call the function
+# directly and rely on its own error handling (returns non-zero on failure).
+
+@test "create_test_repo_with_submodule: single default submodule" {
+  create_test_repo_with_submodule
+
+  local parent="$TEST_PARENT_REPO"
+  [[ -d "$parent" ]]
+  [[ -f "$parent/.gitmodules" ]]
+  [[ -d "$parent/sub" ]]
+  [[ -f "$parent/sub/content.txt" ]]
+  [[ "${#TEST_SUBMODULE_NAMES[@]}" -eq 1 ]]
+  [[ "${TEST_SUBMODULE_NAMES[0]}" == "sub" ]]
+  [[ "${#TEST_SUBMODULE_PATHS[@]}" -eq 1 ]]
+  [[ "${TEST_SUBMODULE_PATHS[0]}" == "$parent/sub" ]]
+  [[ "${#TEST_SUBMODULE_ORIGINS[@]}" -eq 1 ]]
+}
+
+@test "create_test_repo_with_submodule: multiple named submodules" {
+  create_test_repo_with_submodule pay pay-v2
+
+  local parent="$TEST_PARENT_REPO"
+  [[ -d "$parent" ]]
+  [[ -f "$parent/.gitmodules" ]]
+
+  # Check .gitmodules has both entries
+  grep -q 'path = pay' "$parent/.gitmodules"
+  grep -q 'path = pay-v2' "$parent/.gitmodules"
+
+  # Both submodule dirs exist with content
+  [[ -f "$parent/pay/content.txt" ]]
+  [[ -f "$parent/pay-v2/content.txt" ]]
+
+  [[ "${#TEST_SUBMODULE_NAMES[@]}" -eq 2 ]]
+  [[ "${TEST_SUBMODULE_NAMES[0]}" == "pay" ]]
+  [[ "${TEST_SUBMODULE_NAMES[1]}" == "pay-v2" ]]
+
+  [[ "${#TEST_SUBMODULE_PATHS[@]}" -eq 2 ]]
+  [[ "${TEST_SUBMODULE_PATHS[0]}" == "$parent/pay" ]]
+  [[ "${TEST_SUBMODULE_PATHS[1]}" == "$parent/pay-v2" ]]
+
+  [[ "${#TEST_SUBMODULE_ORIGINS[@]}" -eq 2 ]]
+}
+
+@test "create_test_repo_with_submodule: submodules are initialized" {
+  create_test_repo_with_submodule
+
+  local parent="$TEST_PARENT_REPO"
+  # A properly initialized submodule has a .git file (not dir) pointing
+  # to the parent's .git/modules/<name>
+  [[ -f "$parent/sub/.git" ]]
+  # The submodule should have its own commit history (HEAD exists)
+  [[ -d "$parent/.git/modules/sub" ]]
+  # Verify submodule has content committed
+  grep -q 'sub' "$parent/sub/content.txt"
+}

--- a/tests/unit/test_dispatcher.bats
+++ b/tests/unit/test_dispatcher.bats
@@ -1,0 +1,389 @@
+#!/usr/bin/env bats
+# Tests for the hug dispatcher's global flag parsing.
+#
+# The dispatcher (bin/hug) supports two global flags consumed BEFORE the command
+# reaches the SCM detection / case statement:
+#
+#   -C <path>           cd into <path> before dispatch (SCM-agnostic)
+#   -S <name|path>      resolve a git submodule and cd into it
+#   --submodule=<name>  long form of -S
+#
+# Design rationale (from bin/hug comments):
+#   Global flags use `cd` rather than `exec git -C` so that SCM detection
+#   inspects the TARGET directory, and clone/init/help dispatch works from
+#   the cd'd directory. Unknown flags fall through (break) so they remain
+#   in $@ for the command. Command names are never '-'-prefixed, so they
+#   also break correctly.
+#
+# Test matrix:
+#   T1–T3c : -C basic, error, and edge cases
+#   T4–T10 : -S name, path, error, containment, and long form
+#   T11–T12: composition (-C + -S), subdir resolution, name ambiguity
+#   R1–R7  : regressions (no-flag behavior, namespace overlap, passthrough)
+
+load '../test_helper'
+
+# ===========================================================================
+# -C tests: cd into target directory before dispatch
+# ===========================================================================
+
+@test "hug -C <repo> s: runs status in target repo" {
+  create_test_repo
+  local other_repo
+  other_repo=$(create_test_repo)
+  cd "$TEST_REPO"  # be in some repo
+  run hug -C "$other_repo" s
+  assert_success
+  # Output should mention the other repo's HEAD, not ours
+  assert_output --partial "HEAD"
+}
+
+@test "hug -C <repo> s --branch: reports target repo branch" {
+  create_test_repo
+  local other_repo
+  other_repo=$(create_test_repo)
+  cd "$TEST_REPO"
+  run hug -C "$other_repo" s --branch
+  assert_success
+  assert_output --partial "main"
+}
+
+@test "hug -C <repo> ll -1: log from target repo" {
+  create_test_repo
+  local other_repo
+  other_repo=$(create_test_repo)
+  cd "$TEST_REPO"
+  run hug -C "$other_repo" ll -1
+  assert_success
+  assert_output --partial "Initial commit"
+}
+
+@test "hug -C <repo> s: works from non-git directory" {
+  local repo
+  repo=$(create_test_repo)
+  cd /tmp  # KEY BUG FIX: -C from a non-git CWD must work
+  run hug -C "$repo" s
+  assert_success
+  assert_output --partial "HEAD"
+}
+
+@test "hug -C <hg-repo> s: SCM-agnostic (works with Mercurial)" {
+  # Mercurial may not be installed — skip gracefully
+  command -v hg >/dev/null 2>&1 || skip "hg not installed"
+  local hg_repo
+  hg_repo=$(create_test_hg_repo)
+  cd /tmp  # not in any repo
+  run hug -C "$hg_repo" s
+  assert_success
+  rm -rf "$hg_repo"
+}
+
+@test "hug -C <missing-dir>: error for nonexistent directory" {
+  run hug -C /nonexistent/path/xyz s
+  assert_failure
+  assert_output --partial "not a directory"
+}
+
+@test "hug -C: error when no path given (not unbound variable)" {
+  # WHY this test: without the ${2:-} guard, bash's set -u would crash
+  # with "unbound variable" instead of a helpful message.
+  run hug -C
+  assert_failure
+  assert_output --partial "requires a path"
+}
+
+@test "hug -C <file>: error when target is a file" {
+  local tmpf
+  tmpf=$(mktemp)
+  run hug -C "$tmpf" s
+  assert_failure
+  assert_output --partial "not a directory"
+  rm -f "$tmpf"
+}
+
+@test "hug -C '<path with spaces>': works with spaces in path" {
+  create_test_repo
+  local spaced_dir
+  spaced_dir=$(mktemp -d '/tmp/hug test repo XXXXXX')
+  (
+    cd "$spaced_dir" || exit 1
+    git init -q --initial-branch=main 2>/dev/null || git init -q
+    git config user.email "test@test"
+    git config user.name "Test"
+    echo "x" > f.txt && git add f.txt && git commit -q -m "init"
+  )
+  cd /tmp
+  run hug -C "$spaced_dir" s
+  assert_success
+  rm -rf "$spaced_dir"
+}
+
+# ===========================================================================
+# -S tests: resolve git submodule and cd into it
+# ===========================================================================
+
+@test "hug -S <name> s: status of submodule by name" {
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  run hug -S sub s
+  assert_success
+}
+
+@test "hug -S <name> s --branch: submodule branch query" {
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  run hug -S sub s --branch
+  assert_success
+  assert_output --partial "main"
+}
+
+@test "hug -S <path> s: status of submodule by path" {
+  # When the submodule name happens to also be its path (common case),
+  # both name and path resolution should work identically.
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  run hug -S sub s
+  assert_success
+}
+
+@test "hug -S <nonexistent>: error lists available submodules" {
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  run hug -S nonexistent s
+  assert_failure
+  assert_output --partial "not found"
+  # The error message should list the available submodule name
+  assert_output --partial "sub"
+}
+
+@test "hug -S: error when no submodule name given" {
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  run hug -S
+  assert_failure
+  assert_output --partial "requires a submodule"
+}
+
+@test "hug -S ../../other: rejects path outside repo (containment)" {
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  run hug -S ../../etc s
+  assert_failure
+  # ../../etc doesn't match any submodule name or path, so it hits "not found"
+  # before the containment check. Either "not found" or "outside the
+  # repository" is an acceptable rejection — the important thing is it fails.
+  [[ "$output" == *"not found"* || "$output" == *"outside the repository"* ]]
+}
+
+@test "hug -S /abs/path: rejects absolute path" {
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  run hug -S /tmp s
+  assert_failure
+  # Absolute paths won't match any submodule name or relative path,
+  # so they hit "not found" — not "outside the repository".
+  # Either message is acceptable as long as we get failure.
+  assert_failure
+}
+
+@test "hug -S <uninitialized>: suggests git submodule update --init" {
+  # Create repo with submodule, then deinit it so it becomes uninitialized
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  # WHY git submodule deinit: removes the submodule's working tree while
+  # keeping the .gitmodules entry — exactly the "uninitialized" state.
+  git submodule deinit -f sub 2>/dev/null || true
+  run hug -S sub s
+  assert_failure
+  assert_output --partial "not initialized"
+  assert_output --partial "git submodule update --init"
+}
+
+@test "hug --submodule=<name> s: long form of -S" {
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  run hug --submodule=sub s
+  assert_success
+}
+
+@test "hug --submodule= (empty): error when long form has no value" {
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  run hug --submodule= s
+  assert_failure
+  assert_output --partial "requires a submodule"
+}
+
+# ===========================================================================
+# Composition tests: -C and -S together, subdir resolution, name ambiguity
+# ===========================================================================
+
+@test "hug -C <repo> -S <name> s: composition of both global flags" {
+  create_test_repo_with_submodule
+  cd /tmp  # not in the parent repo at all
+  run hug -C "$TEST_PARENT_REPO" -S sub s
+  assert_success
+}
+
+@test "hug -S: exact name match with multiple submodules (no prefix confusion)" {
+  # When two submodules share a prefix (pay, pay-v2), -S must match
+  # the EXACT name, not a prefix. This prevents "pay" silently resolving
+  # to "pay-v2" or vice-versa.
+  create_test_repo_with_submodule pay pay-v2
+  cd "$TEST_PARENT_REPO"
+  run hug -S pay s
+  assert_success
+}
+
+@test "hug -S: exact name match for pay-v2 (no prefix confusion)" {
+  create_test_repo_with_submodule pay pay-v2
+  cd "$TEST_PARENT_REPO"
+  run hug -S pay-v2 s
+  assert_success
+}
+
+@test "hug -S <name> from subdir: resolves via repo top-level" {
+  # Submodule paths in .gitmodules are relative to the repo root.
+  # When CWD is a subdirectory, -S must still find the submodule by
+  # resolving .gitmodules from the repo top-level (git rev-parse --show-toplevel).
+  create_test_repo_with_submodule
+  cd "$TEST_PARENT_REPO"
+  mkdir -p subdir
+  cd subdir
+  run hug -S sub s
+  assert_success
+}
+
+@test "hug -S: error in non-git directory" {
+  cd /tmp  # not a git repo
+  run hug -S anything s
+  assert_failure
+  assert_output --partial "not in a Git repository"
+}
+
+@test "hug -S: error in Mercurial repo (submodules are git-only)" {
+  command -v hg >/dev/null 2>&1 || skip "hg not installed"
+  local hg_repo
+  hg_repo=$(create_test_hg_repo)
+  cd "$hg_repo"
+  run hug -S anything s
+  assert_failure
+  assert_output --partial "Mercurial"
+  rm -rf "$hg_repo"
+}
+
+@test "hug -S: error when repo has no submodules (.gitmodules missing)" {
+  create_test_repo
+  cd "$TEST_REPO"
+  run hug -S anything s
+  assert_failure
+  assert_output --partial ".gitmodules"
+}
+
+# ===========================================================================
+# Regression tests: existing behavior must not change
+# ===========================================================================
+
+@test "regression: hug s works without global flags" {
+  create_test_repo
+  cd "$TEST_REPO"
+  run hug s
+  assert_success
+  assert_output --partial "HEAD"
+}
+
+@test "regression: hug help still dispatches" {
+  run hug help
+  assert_success
+  # hughelp shows the top-level category listing
+  assert_output --partial "command groups"
+}
+
+@test "regression: hug --version still works" {
+  run hug --version
+  assert_success
+  assert_output --partial "Hug SCM"
+}
+
+@test "regression: hug version still works (long form)" {
+  run hug version
+  assert_success
+  assert_output --partial "Hug SCM"
+}
+
+@test "regression: hug clone dispatch still works (no args = error)" {
+  # Running clone without a URL should produce an error from the clone
+  # handler, proving the dispatcher routed correctly.
+  run hug clone
+  assert_failure
+}
+
+@test "regression: hug init dispatch still works (no args = error)" {
+  run hug init
+  assert_failure
+}
+
+@test "regression: hug s -C still means --counts (not global -C)" {
+  # CRITICAL namespace overlap: `hug s -C` is a SUBCOMMAND flag (--counts)
+  # that appears AFTER the command name. The global flag loop only consumes
+  # flags BEFORE the command, so -C after `s` must pass through to git-s.
+  create_test_repo
+  cd "$TEST_REPO"
+  # Stage a file so -C (counts) has something to report
+  echo "x" > newfile.txt && git add newfile.txt
+  run hug s -C
+  assert_success
+  # The key assertion: this does NOT fail with "requires a path" from the
+  # global flag parser. --counts mode outputs "staged unstaged" counts only,
+  # which for a clean repo + one staged file would be something like "1 0".
+  [[ ! "$output" == *"requires a path"* ]]
+}
+
+@test "regression: hug s -S still means --staged (not global -S)" {
+  # Same namespace overlap as -C: `hug s -S` means --staged when it
+  # appears after the command name.
+  create_test_repo
+  cd "$TEST_REPO"
+  echo "x" > staged.txt && git add staged.txt
+  run hug s -S
+  assert_success
+  # Should NOT fail with "requires a submodule"
+  # --staged outputs a count of staged files only (e.g., "1")
+  [[ ! "$output" == *"requires a submodule"* ]]
+}
+
+@test "regression: unknown global flag passes through to git" {
+  # -p is not a hug global flag, so the while-loop's `*) break` fires,
+  # leaving -p in $@ for git to handle. The command should not fail with
+  # "unknown flag" from hug's dispatcher.
+  create_test_repo
+  cd "$TEST_REPO"
+  run hug -p s
+  # git status -p is not a valid combination, so git itself may fail,
+  # but the failure must come from git — not from hug's dispatcher.
+  # We only assert that hug does not produce its own "unknown flag" error.
+  if [[ $status -ne 0 ]]; then
+    # If it failed, make sure it's NOT hug's dispatcher complaining
+    [[ ! "$output" == *"unknown"* ]]
+  fi
+}
+
+@test "regression: -- ends global flags, rest passes to command" {
+  create_test_repo
+  cd "$TEST_REPO"
+  # -- should end the global flag loop; everything after goes to git
+  run hug -- s
+  assert_success
+  assert_output --partial "HEAD"
+}
+
+@test "regression: hug with no args in git repo shows hughelp" {
+  create_test_repo
+  cd "$TEST_REPO"
+  # No args → dispatcher's help branch fires (before SCM detection), showing
+  # the top-level hughelp listing (exit 0). This is by design: hug with no
+  # args is more helpful than git's raw error.
+  run hug
+  assert_success
+  assert_output --partial "command groups"
+}

--- a/tests/unit/test_dispatcher.bats
+++ b/tests/unit/test_dispatcher.bats
@@ -281,6 +281,51 @@ load '../test_helper'
 }
 
 # ===========================================================================
+# -S tests: submodule names containing spaces (issue #157)
+# ===========================================================================
+
+@test "hug -S 'my lib' s: resolves submodule name with spaces" {
+  create_test_repo_with_submodule "my lib"
+  cd "$TEST_PARENT_REPO"
+  run hug -S "my lib" s
+  assert_success
+}
+
+@test "hug -S <nonexistent>: error lists full spaced name (not truncated)" {
+  create_test_repo_with_submodule "my lib"
+  cd "$TEST_PARENT_REPO"
+  run hug -S nonexistent s
+  assert_failure
+  assert_output --partial "not found"
+  # The "Available submodules" listing must show the FULL name "my lib",
+  # not the truncated "my" that the old first-space-split bug produced.
+  assert_output --partial "my lib"
+}
+
+@test "hug -S 'vendor deps' s: resolves by path when name has spaces" {
+  # When name == path (common case), both name and path resolution should work.
+  create_test_repo_with_submodule "vendor deps"
+  cd "$TEST_PARENT_REPO"
+  run hug -S "vendor deps" s
+  assert_success
+}
+
+@test "hug -C <repo> -S 'my lib' s: composition with spaced submodule name" {
+  create_test_repo_with_submodule "my lib"
+  cd /tmp  # not in the parent repo at all
+  run hug -C "$TEST_PARENT_REPO" -S "my lib" s
+  assert_success
+}
+
+@test "hug -S: resolves among multiple spaced-name submodules" {
+  # Two submodules both with spaces — exact match must distinguish them.
+  create_test_repo_with_submodule "my lib" "vendor deps"
+  cd "$TEST_PARENT_REPO"
+  run hug -S "vendor deps" s
+  assert_success
+}
+
+# ===========================================================================
 # Regression tests: existing behavior must not change
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Fixes #157 — the `-S` global flag in `bin/hug` failed to resolve submodules whose names contain spaces (e.g. `"my lib"`, `"vendor deps"`).

**Root cause:** `git config --get-regexp` outputs `key value` separated by a single space, but the key itself can contain spaces when the submodule name has spaces. The old code split on the first space, silently truncating the config key.

**Fix:** Replace `--get-regexp` + first-space-split with `--null --get-regexp` feeding into Bash associative arrays. The NUL-delimited format (`key\nvalue\0`) makes parsing unambiguous regardless of spaces in names or paths.

## Changes

- **`bin/hug`** (lines 95-138): NUL-delimited parsing with `_sub_name_to_path` / `_sub_path_to_name` associative arrays. O(1) resolution replaces three O(N) loops. Error listing is now sorted and deterministic.
- **`tests/unit/test_dispatcher.bats`**: 5 new tests covering spaced submodule names.

## Test Coverage

All 42 dispatcher tests pass (27 existing + 5 new + 10 prior). Full BATS suite passes with no regressions.

New tests:
- `hug -S "my lib" s` — name match with spaces
- `hug -S <nonexistent>` — error lists full spaced name (not truncated)
- `hug -S "vendor deps" s` — path match with spaces
- `hug -C <repo> -S "my lib" s` — composition
- `hug -S` with multiple spaced-name submodules — exact disambiguation

## References

- Found by: [Codex review on PR #156](https://github.com/elifarley/hug-scm/pull/156#discussion_r3326810494)
- Design spec: `docs/superpowers/specs/2026-05-29-fix-s-flag-spaces-in-submodule-names-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)