### PR TITLE
feat(s): add -r, --remote query flag to output tracking remote URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Hug SCM project will be documented in this file.
 
 ### Added
 
+- **`hug s -r, --remote` query flag:** Outputs the fetch URL of the tracking remote (empty when no upstream is configured). Part of the `hug s` query flag system for scripting. Use `hug s -r` alone or combine: `hug s -b -r -u`.
 - **Unified Selection Framework (`selection_core.py`).** Shared toolkit for all Python selection modules: `bash_escape`, `BashDeclareBuilder`, `parse_numbered_input`, `get_selection_input`, `add_common_cli_args`, and ANSI color constants. Adding a new selection domain now requires ~50 lines instead of ~200.
 - **Branch single-select Python migration.** `print_interactive_branch_menu()` now delegates formatting and numbered-list interaction to Python via `branch_select.py prepare` and `single-select` commands. Eval output validated before execution.
 - **Per-item CLI args for subjects and tracks.** `--subject`/`--track` repeated flags replace space-joined `--subjects`/`--tracks` to prevent multi-word commit subjects from being split incorrectly.

--- a/completions/hug-completion.bash
+++ b/completions/hug-completion.bash
@@ -198,6 +198,14 @@ _hug() {
         return 0
     fi
     
+    # Handle options for 'hug s' (query flags for scripting — no positional args)
+    if [[ "$subcmd" == "s" ]]; then
+        if [[ $cur == -* ]]; then
+            COMPREPLY=( $(compgen -W "-r --remote -b --branch -u --upstream -H --hash -s --short-hash -A --ahead -B --behind -C --counts -I --ignored -K --untracked -S --staged -U --unstaged --ball -z --null --json -h --help" -- "$cur" ) )
+        fi
+        return 0
+    fi
+
     # Handle options for top-level HEAD commands (back, undo, rollback, rewind, squash, files)
     if [[ "$subcmd" =~ ^(back|undo|rollback|rewind)$ ]]; then
         if [[ $cur == -* ]]; then

--- a/completions/hug.fish
+++ b/completions/hug.fish
@@ -231,9 +231,24 @@ for sub in sl sla sli statusbase
     complete -c hug -n "__fish_seen_subcommand_from $sub" -s h -l help -d "Help"
 end
 
-# s: Quick summary (no args, no files)
-complete -c hug -n "__fish_seen_subcommand_from s" -f -d "Quick summary (no args)"
+# s: Quick summary (query flags for scripting)
+complete -c hug -n "__fish_seen_subcommand_from s" -f -d "Quick summary (query flags for scripting)"
 complete -c hug -n "__fish_seen_subcommand_from s" -s h -l help -d "Help"
+complete -c hug -n "__fish_seen_subcommand_from s" -s r -l remote -d "URL of tracking remote"
+complete -c hug -n "__fish_seen_subcommand_from s" -s b -l branch -d "Current branch name"
+complete -c hug -n "__fish_seen_subcommand_from s" -s u -l upstream -d "Upstream tracking branch"
+complete -c hug -n "__fish_seen_subcommand_from s" -s H -l hash -d "Full commit hash"
+complete -c hug -n "__fish_seen_subcommand_from s" -s s -l short-hash -d "Short commit hash"
+complete -c hug -n "__fish_seen_subcommand_from s" -s A -l ahead -d "Commits ahead of upstream"
+complete -c hug -n "__fish_seen_subcommand_from s" -s B -l behind -d "Commits behind upstream"
+complete -c hug -n "__fish_seen_subcommand_from s" -s C -l counts -d "Ahead/behind counts"
+complete -c hug -n "__fish_seen_subcommand_from s" -s I -l ignored -d "Ignored file count"
+complete -c hug -n "__fish_seen_subcommand_from s" -s K -l untracked -d "Untracked file count"
+complete -c hug -n "__fish_seen_subcommand_from s" -s S -l staged -d "Staged file count"
+complete -c hug -n "__fish_seen_subcommand_from s" -s U -l unstaged -d "Unstaged file count"
+complete -c hug -n "__fish_seen_subcommand_from s" -l ball -d "State emoji"
+complete -c hug -n "__fish_seen_subcommand_from s" -s z -l null -d "NUL-separated output"
+complete -c hug -n "__fish_seen_subcommand_from s" -l json -d "JSON status output"
 
 # ss/su/sw: Optional [<file>] + help
 for sub in ss su sw

--- a/docs/commands/status-staging.md
+++ b/docs/commands/status-staging.md
@@ -27,7 +27,7 @@ These enhance Git's `status` and `add` with colored summaries, patches, and smar
 
 | Command | Memory Hook | Summary |
 | --- | --- | --- |
-| `hug s` | **S**tatus snapshot | Colored summary of staged/unstaged changes |
+| `hug s` | **S**tatus snapshot | Colored summary of staged/unstaged changes; supports query flags for scripting |
 | `hug sl` | **S**tatus + **L**ist | Status with listed tracked changes |
 | `hug sla` | **S**tatus + **L**ist **A**ll | Status including untracked files |
 | `hug ss` | **S**tatus + **S**taged | Show staged diff |
@@ -42,9 +42,38 @@ These enhance Git's `status` and `add` with colored summaries, patches, and smar
 
 ### Basic Status
 - `hug s`: **S**tatus snapshot
-    - **Description**: Quick colored summary of staged/unstaged changes (no untracked files).
-    - **Example**: `hug s` (always safe, no args).
+    - **Description**: Quick colored summary of staged/unstaged changes (no untracked files). Also supports query flags for scriptable field extraction.
+    - **Example**: `hug s` (always safe, no args), `hug s -r` (remote URL), `hug s -b -r -u` (branch, remote, upstream).
     - **Safety**: ✅ Read-only overview; nothing is modified.
+
+    ::: details Query Flags
+    When any query flag is passed, `hug s` enters **query mode**: individual fields are printed to stdout (one per line by default, NUL-separated with `-z`), with no colored output or chatter on stderr. Computation is lazy — only requested fields incur git operations.
+
+    | Flag | Field | Notes |
+    | --- | --- | --- |
+    | `-b, --branch` | Current branch name | Empty if detached HEAD |
+    | `-r, --remote` | URL of tracking remote | Empty if no upstream |
+    | `-u, --upstream` | Upstream tracking branch | Empty if none |
+    | `-H, --hash` | Full commit hash | HEAD |
+    | `-s, --short-hash` | Short commit hash | HEAD |
+    | `-A, --ahead` | Commits ahead of upstream | Count |
+    | `-B, --behind` | Commits behind upstream | Count |
+    | `-C, --counts` | Combined ahead/behind | `ahead behind` |
+    | `-I, --ignored` | Ignored file count | |
+    | `-K, --untracked` | Untracked file count | |
+    | `-S, --staged` | Staged file count | |
+    | `-U, --unstaged` | Unstaged file count | |
+    | `--ball` | State emoji | Encodes repo state |
+    | `-z, --null` | NUL separator | Use with other query flags |
+    | `--json` | Full JSON output | Mutually exclusive with query flags |
+
+    Query flags are mutually exclusive with `--json`. Combine freely:
+    ```
+    hug s -r                    # URL of tracking remote
+    hug s -b -r -u              # Branch, remote URL, upstream (tab-separated)
+    hug s -z -b -H | xargs -0  # NUL-separated for unusual names
+    ```
+    :::
 
 - `hug sl`: **S**tatus + **L**ist
     - **Description**: Status with a list of *uncommitted* tracked files (mirrors plain `git status`).

--- a/docs/meta/hug-completion-reference.md
+++ b/docs/meta/hug-completion-reference.md
@@ -202,7 +202,7 @@ Subcommands (gateway to specific scripts):
 - `caa [git-commit-opts]`: Commit all. No positional args. Options: Pass-through to `git commit`.
 
 ### s (Status Summary, via git-s)
-- `s`: Quick colored summary. No args/options (use `-h` for help).
+- `s`: Quick colored summary. Query flags: `-b`, `-r`, `-u`, `-H`, `-s`, `-A`, `-B`, `-C`, `-I`, `-K`, `-S`, `-U`, `--ball`, `-z`, `--json`.
 
 ### ss (Staged Status, via git-ss)
 - `ss [<file>]`: Status + staged patch. Args: `[<file>]` (optional). Use `-h` for help.

--- a/git-config/bin/git-s
+++ b/git-config/bin/git-s
@@ -31,10 +31,12 @@ OUTPUT MODES:
 QUERY FLAGS:
   Extract individual fields for scripting. When any query flag is present,
   the command enters query mode: fields are printed to stdout (one per
-  line by default), with no colored output or chatter on stderr.
+  line, or space-separated with multiple flags), with no colored output
+  or chatter on stderr.
   Computation is lazy — only requested fields incur git operations.
 
   -b, --branch     Current branch name (empty if detached).
+  -r, --remote     URL of the tracking remote (empty if none).
   -u, --upstream   Upstream tracking branch name (empty if none).
   -H, --hash       Full commit hash (HEAD).
   -s, --short-hash Short commit hash (HEAD).
@@ -51,6 +53,8 @@ QUERY FLAGS:
   Query flags are mutually exclusive with --json.
 
 DESCRIPTION:
+  Empty output for -r means no upstream tracking branch is configured.
+
   Without flags, prints a colored one-line summary to stderr:
 
     ⚪ HEAD: abc1234 🌿main...origin/main [ahead 2] │ 📦 Staged: ... │ K:3 I:0
@@ -67,6 +71,8 @@ DESCRIPTION:
   In query mode, each flag outputs its corresponding field value to stdout,
   making it safe for pipes and scripting. Multiple flags output fields in
   canonical order, space-separated (or NUL-separated with -z).
+  Canonical order: branch remote upstream hash short-hash ahead behind
+  staged unstaged untracked ignored ball
 
 CAPTURING OUTPUT:
   Default mode outputs to stderr (safe to capture the summary line).
@@ -107,13 +113,13 @@ error() {
 # ---------------------------------------------------------------------------
 
 # getopt short→long mapping:
-#   b=branch u=upstream H=hash s=short-hash A=ahead B=behind
+#   b=branch r=remote u=upstream H=hash s=short-hash A=ahead B=behind
 #   C=counts I=ignored K=untracked S=staged U=unstaged
 #   h=help z=null   --ball and --json are long-only
 set +e # Temporarily disable exit-on-error to capture getopt failure
 PARSED=$(getopt \
-  --options 'buHsABCIKSUhz' \
-  --longoptions 'branch,upstream,hash,short-hash,ahead,behind,counts,untracked,ignored,staged,unstaged,ball,json,help,null' \
+  --options 'rbuHsABCIKSUhz' \
+  --longoptions 'remote,branch,upstream,hash,short-hash,ahead,behind,counts,untracked,ignored,staged,unstaged,ball,json,help,null' \
   --name 'hug s' \
   -- "$@" 2>&1)
 getopt_status=$?
@@ -138,6 +144,7 @@ json_output=false
 
 # Query flags -- using _qs_ prefix (query-status) so Task 2 can extend these
 _qs_branch=false
+_qs_remote=false
 _qs_upstream=false
 _qs_hash=false
 _qs_short_hash=false
@@ -168,6 +175,10 @@ while true; do
   # Query flags
   -b | --branch)
     _qs_branch=true
+    shift
+    ;;
+  -r | --remote)
+    _qs_remote=true
     shift
     ;;
   -u | --upstream)
@@ -233,7 +244,7 @@ done
 # ---------------------------------------------------------------------------
 
 is_query=false
-if $_qs_branch || $_qs_upstream || $_qs_hash || $_qs_short_hash ||
+if $_qs_branch || $_qs_remote || $_qs_upstream || $_qs_hash || $_qs_short_hash ||
   $_qs_ahead || $_qs_behind || $_qs_counts || $_qs_untracked ||
   $_qs_ignored || $_qs_staged || $_qs_unstaged || $_qs_ball; then
   is_query=true
@@ -275,6 +286,25 @@ if $is_query; then
   # --- branch ---
   _qs_val_branch=""
   $_qs_branch && _qs_val_branch=$(git branch --show-current 2> /dev/null || echo "")
+
+  # --- remote URL ---
+  # Resolution: extract remote name from tracking branch via git for-each-ref.
+  # Returns empty when no upstream is configured (detached HEAD, local-only branch).
+  # WHY for-each-ref instead of parameter expansion:
+  #   - Naturally handles detached HEAD (symbolic-ref fails → empty)
+  #   - No fragile string parsing of "origin/main" → "origin"
+  #   - Works with unusual remote names containing "/"
+  _qs_val_remote=""
+  if $_qs_remote; then
+    _qs_remote_name=""
+    _qs_sym_ref=$(git symbolic-ref -q HEAD 2>/dev/null || echo "")
+    if [ -n "$_qs_sym_ref" ]; then
+      _qs_remote_name=$(git for-each-ref --format='%(upstream:remotename)' "$_qs_sym_ref" 2>/dev/null || echo "")
+    fi
+    if [ -n "$_qs_remote_name" ]; then
+      _qs_val_remote=$(git remote get-url "$_qs_remote_name" 2>/dev/null || echo "")
+    fi
+  fi
 
   # --- upstream ---
   _qs_val_upstream=""
@@ -342,7 +372,7 @@ if $is_query; then
   fi
 
   # --- Build and emit output in canonical order ---
-  # Order: branch upstream hash short-hash ahead behind staged unstaged untracked ignored ball
+  # Order: branch remote upstream hash short-hash ahead behind staged unstaged untracked ignored ball
   #
   # WHY direct printf instead of string concatenation:
   #   Bash variables cannot hold NUL bytes (C-string limitation). When
@@ -365,6 +395,7 @@ if $is_query; then
   }
 
   $_qs_branch && _qs_emit "$_qs_val_branch"
+  $_qs_remote && _qs_emit "$_qs_val_remote"
   $_qs_upstream && _qs_emit "$_qs_val_upstream"
   $_qs_hash && _qs_emit "$_qs_val_hash"
   $_qs_short_hash && _qs_emit "$_qs_val_short_hash"

--- a/tests/unit/test_status_query_flags.bats
+++ b/tests/unit/test_status_query_flags.bats
@@ -495,3 +495,206 @@ teardown() {
   cd "$TEST_REPO"
   rm -rf "$nongit_dir"
 }
+
+# ---------------------------------------------------------------------------
+# -r / --remote query flag tests
+# Outputs the fetch URL of the tracking remote (empty if no upstream).
+# Uses git for-each-ref --format='%(upstream:remotename)' + git remote get-url.
+# ---------------------------------------------------------------------------
+
+@test "hug s -r: outputs remote URL with upstream set" {
+  local repo
+  repo=$(create_test_repo_with_remote_upstream)
+  cd "$repo"
+
+  run hug s -r
+  assert_success
+  # Should output the remote URL (a local path to the bare repo)
+  [[ -n "$output" ]]
+  [[ "$output" == *"/origin.git" ]]
+
+  cd "$TEST_REPO"
+}
+
+@test "hug s -r: empty output with no remote" {
+  # Fresh init, no remote at all
+  local no_remote_repo
+  no_remote_repo=$(mktemp -d)
+  git init -q "$no_remote_repo"
+  git -C "$no_remote_repo" config user.name "Test"
+  git -C "$no_remote_repo" config user.email "test@test.com"
+  echo "x" > "$no_remote_repo/file"
+  git -C "$no_remote_repo" add file
+  git -C "$no_remote_repo" commit -q -m "init"
+  cd "$no_remote_repo"
+
+  run hug s -r
+  assert_success
+  [[ -z "$output" ]]
+
+  cd "$TEST_REPO"
+  rm -rf "$no_remote_repo"
+}
+
+@test "hug s -r: empty output when origin exists but branch has no upstream" {
+  local no_upstream_repo
+  no_upstream_repo=$(mktemp -d)
+  git init -q "$no_upstream_repo"
+  git -C "$no_upstream_repo" config user.name "Test"
+  git -C "$no_upstream_repo" config user.email "test@test.com"
+  echo "x" > "$no_upstream_repo/file"
+  git -C "$no_upstream_repo" add file
+  git -C "$no_upstream_repo" commit -q -m "init"
+  # Add a remote but do NOT set upstream tracking
+  local remote_dir
+  remote_dir=$(mktemp -d)
+  git init --bare -q "$remote_dir"
+  git -C "$no_upstream_repo" remote add origin "$remote_dir"
+  cd "$no_upstream_repo"
+
+  run hug s -r
+  assert_success
+  [[ -z "$output" ]]
+
+  cd "$TEST_REPO"
+  rm -rf "$no_upstream_repo" "$remote_dir"
+}
+
+@test "hug s -b -r: outputs branch and remote URL space-separated" {
+  local repo
+  repo=$(create_test_repo_with_remote_upstream)
+  cd "$repo"
+
+  run hug s -b -r
+  assert_success
+  local branch url
+  branch=$(hug s -b)
+  url=$(hug s -r)
+  assert_output "$branch $url"
+
+  cd "$TEST_REPO"
+}
+
+@test "hug s -b -r -u: outputs in canonical order" {
+  local repo
+  repo=$(create_test_repo_with_remote_upstream)
+  cd "$repo"
+
+  local branch remote_url upstream
+  branch=$(hug s -b)
+  remote_url=$(hug s -r)
+  upstream=$(hug s -u)
+
+  run hug s -b -r -u
+  assert_success
+  assert_output "$branch $remote_url $upstream"
+
+  cd "$TEST_REPO"
+}
+
+@test "hug s -z -b -r -H: NUL-separated output" {
+  local repo
+  repo=$(create_test_repo_with_remote_upstream)
+  cd "$repo"
+
+  local branch remote_url hash
+  branch=$(hug s -b)
+  remote_url=$(hug s -r)
+  hash=$(hug s -H)
+
+  local nul_output
+  nul_output=$(hug s -z -b -r -H | xxd -p | tr -d '\n')
+  local expected_hex
+  expected_hex=$(printf '%s\0%s\0%s\n' "$branch" "$remote_url" "$hash" | xxd -p | tr -d '\n')
+  [[ "$nul_output" == "$expected_hex" ]]
+
+  cd "$TEST_REPO"
+}
+
+@test "hug s -r: no output on stderr" {
+  local repo
+  repo=$(create_test_repo_with_remote_upstream)
+  cd "$repo"
+
+  run bash -c 'hug s -r 2>&1 1>/dev/null'
+  assert_success
+  [[ -z "$output" ]]
+
+  cd "$TEST_REPO"
+}
+
+@test "hug s --remote: exits 0 (long form)" {
+  run hug s --remote
+  assert_success
+}
+
+@test "hug s -r: empty output in detached HEAD" {
+  local detached_repo
+  detached_repo=$(mktemp -d)
+  git init -q "$detached_repo"
+  git -C "$detached_repo" config user.name "Test"
+  git -C "$detached_repo" config user.email "test@test.com"
+  echo "x" > "$detached_repo/file"
+  git -C "$detached_repo" add file
+  git -C "$detached_repo" commit -q -m "init"
+  local sha
+  sha=$(git -C "$detached_repo" rev-parse HEAD)
+  git -C "$detached_repo" checkout -q "$sha"
+  cd "$detached_repo"
+
+  run hug s -r
+  assert_success
+  [[ -z "$output" ]]
+
+  cd "$TEST_REPO"
+  rm -rf "$detached_repo"
+}
+
+@test "hug s -r: outputs correct URL for non-origin remote" {
+  local repo
+  repo=$(mktemp -d)
+  git init -q --initial-branch=main "$repo"
+  git -C "$repo" config user.name "Test"
+  git -C "$repo" config user.email "test@test.com"
+  echo "x" > "$repo/file"
+  git -C "$repo" add file
+  git -C "$repo" commit -q -m "init"
+
+  # Create two remotes: origin and upstream
+  local origin_dir upstream_dir
+  origin_dir=$(mktemp -d)
+  upstream_dir=$(mktemp -d)
+  git init --bare -q "$origin_dir"
+  git init --bare -q "$upstream_dir"
+  git -C "$repo" remote add origin "$origin_dir"
+  git -C "$repo" remote add upstream "$upstream_dir"
+  # Push to both remotes (creates refs in bare repos)
+  git -C "$repo" push -q origin main
+  git -C "$repo" push -q upstream main
+  # Set upstream tracking to 'upstream/main' (not origin)
+  git -C "$repo" branch --set-upstream-to=upstream/main
+  cd "$repo"
+
+  run hug s -r
+  assert_success
+  # Should output the upstream remote URL, not origin
+  [[ "$output" == *"$upstream_dir"* ]]
+  [[ "$output" != *"$origin_dir"* ]]
+
+  cd "$TEST_REPO"
+  rm -rf "$repo" "$origin_dir" "$upstream_dir"
+}
+
+@test "hug s --json -r: exits with error (mutual exclusion)" {
+  run hug s --json -r
+  assert_failure
+  [[ "$output" =~ (cannot|incompatible|conflict) ]]
+}
+
+@test "hug s -r: exits 0 in default fixture" {
+  # The default setup (create_test_repo_with_changes) has no upstream
+  # so -r should output empty but exit 0
+  run hug s -r
+  assert_success
+  [[ -z "$output" ]]
+}


### PR DESCRIPTION
## Summary

Adds `-r, --remote` as a query flag to `hug s` that outputs the fetch URL of the tracking remote. Like other query flags, it outputs empty when no upstream is configured.

```bash
remote_url=$(hug s -r)
hug s -b -r -u -H  # branch, remote URL, upstream, hash
```

## Changes

- **`git-config/bin/git-s`** — Added `-r, --remote` query flag using `git for-each-ref --format='%(upstream:remotename)'` to resolve the remote name, then `git remote get-url` for the URL. Follows canonical emit order: branch → remote → upstream → hash → ...
- **`tests/unit/test_status_query_flags.bats`** — 12 new BATS tests covering: basic URL, no remote, no upstream, combined flags, canonical ordering, NUL output, stderr clean, long form, detached HEAD, non-origin remote, --json conflict, default fixture
- **`docs/commands/status-staging.md`** — Updated query flags documentation with `-r` entry
- **`docs/meta/hug-completion-reference.md`** — Updated `hug s` completions to list all query flags
- **`completions/hug.fish`** — Full query flag completions for `hug s`
- **`completions/hug-completion.bash`** — Added `s)` case with all query flags
- **`CHANGELOG.md`** — Entry under `[Unreleased] > Added`

## Test plan

- [x] All 55 query flag tests pass (43 existing + 12 new)
- [x] No regressions in status-staging (142 tests), status-json (11 tests), show (58 tests)
- [x] `hug s -r` outputs remote URL when upstream is set
- [x] `hug s -r` outputs empty when no upstream configured
- [x] `hug s -b -r -u` outputs in canonical order (branch, remote, upstream)
- [x] `hug s --remote` (long form) works identically
- [x] Detached HEAD returns empty output
- [x] Non-origin remotes (e.g., `upstream/main`) resolve correctly

## Deferred items (filed as issues)

- #159 — `hug s --push-url` flag
- #160 — Computation sharing between `-u` and `-r`
- #161 — Fork workflow / `remote.pushDefault` edge-case tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)