### PR TITLE
docs(agents): add hug wtc --base form + freshness guidance to worktrees section

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -44,6 +44,11 @@ jobs:
           make install
           source bin/activate
 
+      - name: Install UV package manager
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
       - name: Install test dependencies
         run: |
           make dev-env-init

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -45,7 +45,9 @@ jobs:
           source bin/activate
 
       - name: Install test dependencies
-        run: make dev-deps-sync
+        run: |
+          make dev-env-init
+          make dev-deps-sync
 
       - name: Install VHS
         run: make vhs-deps-install

--- a/git-config/lib/python/articles/agents.md
+++ b/git-config/lib/python/articles/agents.md
@@ -219,6 +219,7 @@ operation not covered below, report exactly what you need and stop — do not
 attempt a raw git command.
 
 - `hug wtc <branch> --new -y`: create new branch from HEAD + its worktree
+- `hug wtc <branch> --base [remote/]<point> -y`: new branch from a start-point (branch/tag/ref); implies --new
 - `hug wtc <branch> -y`: create worktree for an existing branch
 - `hug wtl`: list all worktrees
 - `hug wtl <search>`: filter by path/branch substring (OR logic)
@@ -226,6 +227,7 @@ attempt a raw git command.
 - `hug wtdel <branch> --force`: delete worktree (add --with-branch to drop branch too)
 
 Worktrees land at a canonical path chosen by hug. Never pass `.worktrees/` or any explicit path to these commands.
+Base a new branch off an UP-TO-DATE integration branch (usually `origin/main` — `hug wtc <branch> --base origin/main -y`), not a stale local HEAD.
 
 ## Where to go next
 

--- a/tests/unit/test_status_staging.bats
+++ b/tests/unit/test_status_staging.bats
@@ -534,21 +534,22 @@ teardown() {
 }
 
 @test "hug untrack: untracks single file when specified" {
-  # Create and commit a file
-  echo "secret" > .env
-  git add .env
-  git commit -q -m "Add .env"
-  
+  # Create and commit a file. Avoid `.env` — it commonly sits in developers'
+  # global gitignores, which makes `git add` fail outside CI.
+  echo "secret" > secret.conf
+  git add secret.conf
+  git commit -q -m "Add secret.conf"
+
   # Untrack it with --force to skip confirmation
-  run hug untrack .env --force
+  run hug untrack secret.conf --force
   assert_success
   assert_output --partial "✅ Success: Untracked 1 file (kept locally):"
-  assert_output --partial ".env"
-  
+  assert_output --partial "secret.conf"
+
   # Verify file is untracked but still exists locally
   run git ls-files
-  refute_output --partial ".env"
-  assert_file_exist .env
+  refute_output --partial "secret.conf"
+  assert_file_exist secret.conf
 }
 
 @test "hug untrack: untracks multiple files when specified" {

--- a/tests/unit/test_untrack.bats
+++ b/tests/unit/test_untrack.bats
@@ -10,21 +10,22 @@ setup() {
 }
 
 @test "hug untrack: supports --from-file flag" {
-  # Create and commit files
-  echo "secret" > .env
+  # Create and commit files. Avoid names that commonly appear in developers'
+  # global gitignores (e.g. `.env`) — those make `git add` fail outside CI.
+  echo "secret" > secret.conf
   echo "config" > config.local.json
   echo "public" > public.txt
-  hug add .env config.local.json public.txt
+  hug add secret.conf config.local.json public.txt
   hug c -m "Add files"
 
   # Create a file list with some files to untrack
-  echo -e ".env\nconfig.local.json" > files.txt
+  echo -e "secret.conf\nconfig.local.json" > files.txt
 
   # Test dry-run first
   run hug untrack --dry-run --from-file files.txt
   assert_success
   assert_output --partial "Would untrack 2 file(s)"
-  assert_output --partial ".env"
+  assert_output --partial "secret.conf"
   assert_output --partial "config.local.json"
 
   # Actually untrack the files
@@ -35,7 +36,7 @@ setup() {
   # Check that files are no longer tracked
   run hug ls-files
   assert_success
-  refute_output --partial ".env"
+  refute_output --partial "secret.conf"
   refute_output --partial "config.local.json"
   assert_output --partial "public.txt"  # Should still be tracked
 }


### PR DESCRIPTION
✅ Add the `hug wtc --base` form and a "branch off up-to-date `origin/main`, not stale HEAD" rule to the worktrees section of `hug help :agents`. The cheatsheet only showed `--new` (branch from HEAD), so an agent following it cut worktrees off a stale local HEAD.

Also fixes two pre-existing CI blockers that surfaced when this PR rebased past the dependabot `actions/checkout` 6→7 bump on the same workflow file, and one local-only test fixture name:

- `copilot-setup-steps` was calling `make dev-deps-sync` without first creating `.venv` (`dev-env-init`) or installing `uv`. Added the two missing steps, mirroring `test.yml`.
- Two `hug untrack` tests used `.env` as the fixture; `.env` lives in most developers' global gitignore, so `git add .env` failed outside CI. Renamed to `secret.conf`.

🟢 Low risk. Docs change is additive; the CI fix only adds setup steps the main `test.yml` already runs; the test rename is a pure fixture-name swap, no assertion logic changed. All checks `SUCCESS`, merge state `CLEAN`.

More context: https://github.com/elifarley/hug-scm/issues/200 (pre-existing flaky `bc --point-to` test, unfixed here, did not recur on this run)

<details><summary>Details</summary>

## Why the docs change

The `hug help :agents` cheatsheet listed only `hug wtc <branch> --new -y` (branches from HEAD). An agent copy-pasting it would cut a new worktree off whatever local HEAD happened to be, even if `origin/main` had advanced. The fix adds the `--base [remote/]<point>` form and a one-line rule: base off an up-to-date `origin/main`, not stale HEAD.

## Why the CI fixes landed in this PR

This PR was docs-only. After rebasing onto `origin/main`, it pulled in the dependabot `actions/checkout` 6→7 bump that lives in `.github/workflows/copilot-setup-steps.yml`. That workflow file is in the PR's diff, so the `copilot-setup-steps` required check triggered and exposed two pre-existing bugs in it:

1. The "Install test dependencies" step called `make dev-deps-sync` directly. That target errors with `❌ .venv not found` unless `dev-env-init` ran first. Fixed by adding `make dev-env-init` before it.
2. `dev-env-init` then errored with `❌ UV is required` because `uv` was never installed on the runner. Fixed by adding an "Install UV package manager" step (curl installer + `$GITHUB_PATH`), matching `.github/workflows/test.yml` lines 23-26.

Both fixes follow the existing pattern in `test.yml` rather than inventing a new one. Filed as separate concerns because they were independently diagnosable, but bundled here because the PR couldn't go green otherwise.

## Why rename `.env` to `secret.conf`

The `hug untrack` tests used `.env` purely as a placeholder for "a file worth untracking". `.env` is in nearly every developer's global gitignore (`~/.gitignore-global`, GitHub's recommended ignores). On such a machine `git add .env` fails with `The following paths are ignored by one of your .gitignore files`, making `make test-unit` look broken outside CI. CI runs without a global gitignore, so the failure was invisible and the rot went unnoticed. `secret.conf` is semantically equivalent but in no standard gitignore, so the tests pass uniformly. Considered alternatives: `git add -f .env` (hides the contributor friction the bug reveals), per-test `core.excludesfile` unset (invasive test_helper change).

</details>
