### PR TITLE
Ship the worktree ritual with hug — `hug help :worktree` + thin skill

### DIFF
--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,47 +1,59 @@
 # Hug Skills
 
-This directory contains Claude Code skills that enhance your experience working with Hug.
+This directory contains skills that enhance your agent's experience working with hug.
+Each skill is a directory containing a `SKILL.md` (some add supporting files).
 
-## Quick Install
+## Install
 
-**One-line installation:**
+Skills live in per-skill directories. Copy the ones you want into your agent's skills
+directory (Claude Code paths shown; adjust the destination for other hosts):
+
 ```bash
-curl -sSL https://raw.githubusercontent.com/elifarley/hug-scm/main/docs/skills/hug-workflow.skill -o ~/.claude/skills/hug-workflow.skill
+# From a clone of this repo:
+cp -r docs/skills/hug-workflow      ~/.claude/skills/
+cp -r docs/skills/hug-worktree      ~/.claude/skills/
+cp -r docs/skills/hug-repo-analysis ~/.claude/skills/
 ```
 
-**Or manual install:**
+Or fetch a single skill's `SKILL.md` directly (works while a skill is exactly one file
+— see the note below):
+
 ```bash
-mkdir -p ~/.claude/skills
-cp docs/skills/hug-workflow.skill ~/.claude/skills/
+mkdir -p ~/.claude/skills/hug-worktree
+curl -sSL https://raw.githubusercontent.com/elifarley/hug-scm/main/docs/skills/hug-worktree/SKILL.md \
+  -o ~/.claude/skills/hug-worktree/SKILL.md
 ```
 
-That's it! Claude Code will automatically discover and load the skill when you work with Git.
+That's it — Claude Code auto-discovers and loads a skill when its triggers match.
+
+> **Note:** the single-file `curl` form holds only while a skill is exactly one
+> `SKILL.md`. `hug-repo-analysis` ships supporting material under `guides/`, so use the
+> `cp -r` (directory) form for it. A multi-file-safe installer is a possible follow-up.
 
 ## What are Skills?
 
-Skills are modular packages that extend Claude's capabilities with specialized knowledge and workflows. When you use Claude Code with Hug-related projects, these skills auto-load to provide better assistance.
+Skills are modular packages that extend an agent's capabilities with specialized
+knowledge and workflows. When you work in hug-related projects, a matching skill
+auto-loads to provide better assistance.
 
 ## Available Skills
 
-### hug-workflow.skill
+### hug-workflow
 
-Git workflow management using Hug (enhanced Git replacement).
+Git workflow management using hug (enhanced git replacement) — staging, committing,
+amending, inspection, history. Auto-triggers on commit/stage/status/log/diff.
 
-**Features:**
-- Safety rules for staging and committing
-- Pre-commit workflows
-- Amend and fix operations
-- Common command reference
+### hug-worktree
 
-**Auto-triggers when:**
-- You mention committing, staging, or Git operations
-- Claude needs to inspect repository state
-- Working with branches or history
+The worktree-first ritual for branch-worthy work: create a worktree before starting,
+work inside it, clean up after merge. Delegates to `hug help :worktree`, so non-skill
+agents get the same ritual straight from hug. Auto-triggers when starting a
+feature/bugfix/refactor/spec.
 
-## Usage
+### hug-repo-analysis
 
-Once installed, skills auto-load when relevant. No manual activation needed - Claude Code detects when a skill is needed based on your conversation context.
+Repository analysis and reporting helpers (ships supporting material under `guides/`).
 
 ## Contributing
 
-Have a skill that improves the Hug workflow? Submit a PR to add it here!
+Have a skill that improves the hug workflow? Open a PR to add it here.

--- a/docs/skills/hug-worktree/SKILL.md
+++ b/docs/skills/hug-worktree/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: hug-worktree
+description: Use whenever starting branch-worthy work (spec/plan documents, features, bugfixes, refactors, multi-step tasks) — the worktree-first ritual.
+argument-hint: "[new-branch-name or task description]"
+allowed-tools: Bash
+---
+
+# Worktree-first workflow (hug)
+
+Branch-worthy work always starts in a fresh worktree, never a bare branch in the main
+checkout — and the worktree is created FIRST, before any other action on the task.
+
+**Run `hug help :worktree` and follow that ritual.** It is the single source of truth
+for the full sequence: when to skip, base-branch selection, provisioning, working
+inside the worktree, sanitize-before-finish, cleanup, and subagent rules. This skill is
+a thin pointer so the ritual can never drift from the article.
+
+Authoritative command syntax lives in `hug help :worktree` and each command's own `-h`
+(`hug wtc -h`, `hug wtl -h`, `hug wtdel -h`) — check there if a flag looks off.
+
+## The safety floor (if you do nothing else)
+
+- Create + enter: `hug -C <repo> wtc <branch> --base origin/main -y`, then `cd` into the
+  sibling `<repo>.WT.<branch>` and do ALL work there.
+- Never use `git worktree` (hard-blocked); never pass an explicit path or `.worktrees/`.
+- After merge: `hug -C <repo> wtdel <branch> --force` (append `--with-branch` to drop the branch).

--- a/docs/skills/hug-worktree/SKILL.md
+++ b/docs/skills/hug-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hug-worktree
-description: Use whenever starting branch-worthy work (spec/plan documents, features, bugfixes, refactors, multi-step tasks) — the worktree-first ritual.
+description: Use whenever starting branch-worthy work (features, bugfixes, refactors, spec/plan documents, multi-step tasks) — the worktree-first ritual.
 argument-hint: "[new-branch-name or task description]"
 allowed-tools: Bash
 ---

--- a/git-config/lib/python/articles/agents.md
+++ b/git-config/lib/python/articles/agents.md
@@ -209,14 +209,7 @@ Force-push variants exist, but default to the safe one:
 
 ## Worktrees — never `git worktree`
 
-**Always start branch-worthy work (spec files/feature/bugfix/refactor/multi-step) in a new worktree — never a bare branch in the main checkout.**
-Creating the worktree is the first step, before any other action on the task.
-WHY: isolation keeps your main checkout clean, enables parallel agent work, and stops half-finished edits from polluting the tree — critical for an autonomous agent.
-**REQUIRED:** Load the `hug-worktree` skill for the full ritual (guards, base-branch selection, cleanup).
-
-You MUST NEVER use `git worktree` for any operation. If you need a worktree
-operation not covered below, report exactly what you need and stop — do not
-attempt a raw git command.
+**Always start branch-worthy work (spec/plan files, feature, bugfix, refactor, multi-step) in a new worktree — never a bare branch in the main checkout; it is the first step, before any other action.** WHY: isolation keeps the main checkout clean, enables parallel agent work, and stops half-finished edits from polluting the tree — critical for an autonomous agent.
 
 - `hug wtc <branch> --new -y`: create new branch from HEAD + its worktree
 - `hug wtc <branch> --base [remote/]<point> -y`: new branch from a start-point (branch/tag/ref); implies --new
@@ -226,11 +219,13 @@ attempt a raw git command.
 - `hug wtl -b <branch>`: filter by exact branch name
 - `hug wtdel <branch> --force`: delete worktree (add --with-branch to drop branch too)
 
-Worktrees land at a canonical path chosen by hug. Never pass `.worktrees/` or any explicit path to these commands.
-Base a new branch off an UP-TO-DATE integration branch (usually `origin/main` — `hug wtc <branch> --base origin/main -y`), not a stale local HEAD.
+Two hard rules: never `git worktree` (hard-blocked — use the `hug wt*` commands above); never pass an explicit path or `.worktrees/` (hug owns the canonical `<repo>.WT.<branch>` path). Base off an UP-TO-DATE integration branch (usually `origin/main`), not a stale local HEAD.
+
+**Full ritual — skip conditions, provisioning, work-inside discipline, cleanup, subagents:** `hug help :worktree`.
 
 ## Where to go next
 
 - `hug help :hug-101` — beginner walkthrough of the daily loop
+- `hug help :worktree` — the full branch-worthy-work worktree ritual
 - `hug help <command>` — full help for any specific command (mind its "see also" footer)
 - Reach for the discovery sigils above (`@` `/` `'!'` `:`) to find anything this cheatsheet omits.

--- a/git-config/lib/python/articles/worktree.md
+++ b/git-config/lib/python/articles/worktree.md
@@ -1,0 +1,77 @@
++++
+title   = "Worktrees: the branch-worthy-work ritual"
+summary = "Always start branch-worthy work in a fresh worktree — the ritual."
+order   = 30
++++
+
+Branch-worthy work — a spec, a plan, a feature, a bugfix, a refactor, any multi-step
+change — ALWAYS starts in a fresh worktree, never a bare branch in the main checkout.
+Creating the worktree is the FIRST step, before any other action on the task (before
+reproducing a bug, before writing a failing test).
+
+WHY: an isolated worktree keeps the main checkout clean and usable, lets independent
+tasks run in parallel, and stops a half-finished change from polluting the working
+tree — which matters most when an autonomous agent is making the edits.
+
+## Skip a new worktree ONLY when
+
+- You are ALREADY inside a worktree dedicated to this task (never nest worktrees).
+- The task is a trivial in-place edit on the already-correct branch.
+- You are only inspecting, read-only.
+
+When in doubt, create the worktree.
+
+## The ritual
+
+1. **Create the branch and its worktree in one step**, based off an UP-TO-DATE
+   integration branch (usually `origin/main` — confirm per repo; some use
+   `origin/develop` or `master`), NOT a stale local HEAD:
+
+       hug -C <repo> wtc <new-branch> --base origin/main -y
+
+   For an existing branch: `hug -C <repo> wtc <existing-branch> -y`. Hug chooses the
+   canonical worktree path (a sibling `<repo>.WT.<branch>`); never pass an explicit
+   path or a `.worktrees/` directory.
+
+2. **Enter the worktree and do all work there.** `cd` INTO it (find it with
+   `hug -C <repo> wtl <branch>`) so `make`, tests, and relative paths target the
+   worktree, not the main checkout. Keep passing `hug -C <worktree>` for clarity.
+
+3. **Provision the environment** when the project ships a Makefile target for it —
+   e.g. a `dev-env-init` target (creates the baseline env) and/or a `deps-sync` target
+   (installs from the lockfile). Run whichever exist, `dev-env-init` before `deps-sync`;
+   both are idempotent and safe to run.
+
+## Work INSIDE the worktree
+
+Creating a worktree and then editing the original checkout — or running `make`/tests
+with the CWD still at the main repo — is the #1 mistake. After you `cd` in, the
+worktree is your working tree for the entire task.
+
+## Before finishing
+
+An automated harness may run the project's `sanitize`/verify target on finish against
+the session's ORIGINAL directory, not a worktree created mid-session — so run the
+project's sanitize/verify yourself, inside the worktree, before you wrap up.
+
+## After merge — clean up
+
+    hug -C <repo> wtdel <branch> --force      # append --with-branch to drop the branch too
+
+List worktrees any time with `hug -C <repo> wtl [branch]`.
+
+## Hard rules
+
+- NEVER use `git worktree` (or any raw git worktree command) — it is hard-blocked.
+  Always use `hug wtc` / `hug wtl` / `hug wtdel`.
+- NEVER pass an explicit path or a `.worktrees/` directory — hug owns the canonical
+  `<repo>.WT.<branch>` path.
+- If you need a worktree operation not covered here, say what you need (and which raw
+  git command would do it) and stop — do not run a raw git command.
+
+## Subagents
+
+A dispatched agent inherits the worktree: if your CWD is a `*.WT.*` directory, just
+work there — every edit and every `hug -C <worktree-path>` stays in that worktree,
+never the sibling repo root. Don't create worktrees as a subagent unless the
+orchestrator delegated it.

--- a/mgmt/plans/2026-07-09-hug-worktree-ship-design.md
+++ b/mgmt/plans/2026-07-09-hug-worktree-ship-design.md
@@ -1,0 +1,174 @@
+# Design: Ship the worktree ritual with hug — `hug help :worktree` + a shipped skill
+
+**Date:** 2026-07-09
+**Status:** Approved
+**Author:** brainstorming session
+
+## Context
+
+Hug ships worktree commands (`hug wtc` / `wtl` / `wtdel`) and an agent guide
+(`hug help :agents`). What it does **not** yet ship is the *ritual* around those
+commands at any depth: always start branch-worthy work in a fresh worktree, base
+it off an up-to-date integration branch, provision it, work **inside** it, clean
+it up after merge. Today that ritual exists only as a cramped section in
+`agents.md`.
+
+Two gaps follow:
+
+1. **Not reachable at depth, tool-agnostically.** Any agent driving hug — Claude
+   Code, Codex, Cursor, Gemini, OpenCode — should get the same ritual, at the
+   same depth, regardless of host. A few lines in one guide isn't that.
+2. **Adding a skill naively would duplicate it.** Skill-aware hosts want a
+   `hug-worktree` *skill* affordance; authored naively, that skill would carry
+   its own copy of the ritual and drift from `agents.md`. The ritual needs one
+   canonical home *before* a second consumer exists.
+
+This design ships the ritual **with hug** as a first-class article
+(`hug help :worktree`) — the canonical home — collapses the `agents.md` section
+to a menu + safety echo + pointer, and adds a **thin, host-neutral skill** that
+delegates to the article (no prose of its own). One prose home, three access
+paths. The article mechanism is the one from `2026-05-06-help-articles-design.md`;
+this is a drop-in markdown file, no loader changes.
+
+## Goals
+
+1. `hug help :worktree` renders the full worktree ritual in the terminal —
+   reachable by any agent or human using hug.
+2. Single source of truth: the ritual prose lives in exactly one place (the
+   article). `agents.md` keeps only a command menu + a minimal safety echo + a
+   pointer.
+3. A shipped, host-neutral `hug-worktree` skill that delegates to the article
+   (no ritual prose of its own), so downstream agent configs can consume it by
+   symlink or copy without forking the content.
+4. The stale `docs/skills/README.md` install path is corrected in the same
+   change (it currently points at a `.skill` bundle that does not exist).
+
+## Non-goals
+
+- **No loader changes.** `articles_loader.py` already glob-discovers
+  `articles/*.md`; `worktree.md` is a drop-in — no registration, no code.
+- **No search integration.** Consistent with the article design, `:worktree`
+  stays in the `:` namespace; it does not appear in `/keyword` or `!intent`.
+- **No new worktree behavior.** Documentation + packaging only; the
+  `wtc` / `wtl` / `wtdel` commands are unchanged.
+- **No host-specific wiring.** How a particular agent config consumes the
+  shipped skill (symlink, copy, per-host dirs) is that config's concern, not
+  hug's. This design stops at "hug ships a consumable skill."
+
+## Approach
+
+The packaging decision (article + thin per-host wrapper) was chosen over two
+alternatives:
+
+| | A — Article + thin shipped skill (chosen) | B — Fat skill only | C — agents.md only |
+|---|---|---|---|
+| Tool-agnostic reach | Yes — any agent via `hug help :worktree` | No — only skill-aware hosts | Yes, but cramped |
+| Single source of truth | Yes — article is canonical | Skill is canonical; agents.md drifts | One place, no skill affordance |
+| Host skill affordance | Yes — thin wrapper delegates | Yes, but duplicates prose | No |
+| Drift risk | Low — one prose home | High — skill vs agents.md | Low |
+
+A wins: the article is the tool-agnostic canonical home; the skill is a thin
+affordance for skill-aware hosts; `agents.md` shrinks to a pointer. One prose
+home, three access paths (`hug help :worktree`, the skill, the agents.md
+pointer).
+
+## Architecture
+
+### Deliverables
+
+```
+git-config/lib/python/articles/
+  worktree.md          ← NEW — full ritual prose (canonical), order=30
+  agents.md            ← SHRINK — worktree section → menu + safety echo + pointer
+docs/skills/
+  hug-worktree/
+    SKILL.md           ← NEW — thin wrapper, delegates to `hug help :worktree`
+  README.md            ← FIX — directory-based install; list all shipped skills
+```
+
+### `worktree.md` — the canonical article
+
+Frontmatter (per the article schema — TOML fenced by `+++`, `summary` ≤ 70
+chars, `order` sorts the listing ascending):
+
+```markdown
++++
+title   = "Worktrees: the branch-worthy-work ritual"
+summary = "Always start branch-worthy work in a fresh worktree — the ritual."
+order   = 30
++++
+```
+
+`order = 30` slots it right after `agents` (20) in `hug help :` — the two
+agent-facing articles sit together. Slug = filename stem → `hug help :worktree`.
+
+Body = the full ritual, **harness-neutral** (no host/tool names in the prose):
+
+- **Worktree-first + WHY** — branch-worthy work (spec / feature / bugfix /
+  refactor / multi-step) always starts in a NEW worktree, never a bare branch in
+  the main checkout; it is the first step, before any other action.
+- **Skip conditions** — trivial one-file edits, read-only inspection, or already
+  being inside the right worktree.
+- **The ritual** — create (`hug wtc <branch> --base [remote/]<pt> -y`, basing
+  off an UP-TO-DATE integration branch, not a stale local HEAD) → work INSIDE
+  the new worktree (the #1 mistake is creating it then editing the main
+  checkout) → provision project deps via the project's Makefile target where one
+  exists (e.g. a `dev-env-init` / deps-sync target) → before finishing, run the
+  project's sanitize/verify → after merge, clean up
+  (`hug wtdel <branch> --force`; `--with-branch` to drop the branch too).
+- **Hard rules** — never `git worktree` (use `hug wtc`); never pass an explicit
+  path or `.worktrees/` (hug chooses the canonical `<repo>.WT.<branch>` path).
+- **Subagent note** — dispatched agents inherit the worktree; they must act
+  inside it, not re-derive a path.
+
+### `agents.md` — shrink to pointer + safety echo
+
+The worktree section collapses to: the command menu, a two-line safety echo
+(never `git worktree`; never an explicit path), and `Full ritual:
+hug help :worktree`. The current "Load the hug-worktree skill …" line becomes
+the `hug help :worktree` pointer. Rationale for keeping a *minimal* echo rather
+than a pure pointer: an agent may act on the command menu without opening the
+article, so the two hardest safety rules stay inline; the depth lives once, in
+the article.
+
+### `docs/skills/hug-worktree/SKILL.md` — thin wrapper
+
+A host-neutral skill whose body is essentially "run `hug help :worktree` and
+follow that ritual," plus an authoritative-syntax pointer (the article and
+`hug help wtc|wtl|wtdel` are the source of truth for flags). No ritual prose of
+its own — it delegates, so it can never drift from the article. Frontmatter:
+`name`, `description` (when to use — starting branch-worthy work), and a minimal
+`allowed-tools` (Bash, to run `hug`).
+
+### `docs/skills/README.md` — fix the install path
+
+Current instructions install a single-file `hug-workflow.skill` bundle that does
+not exist; the real shipped format is a directory (`hug-workflow/SKILL.md`). Fix:
+
+- Replace the `.skill` curl/cp with directory-based install (both current skills
+  are a single `SKILL.md`, so `mkdir -p ~/.claude/skills/<name>` +
+  `curl … /<name>/SKILL.md` works today; plus `cp -r docs/skills/<name>
+  ~/.claude/skills/` for repo clones).
+- List all shipped skills: add `hug-worktree` (note it pairs with
+  `hug help :worktree` for non-skill agents) and backfill `hug-repo-analysis`,
+  which already ships but is undocumented.
+- Note the single-file-curl limitation (holds only while a skill is one
+  `SKILL.md`); a multi-file-safe installer is a possible follow-up, not part of
+  this change.
+
+## Verification
+
+- `hug help :worktree` renders; `hug help :` lists it after `agents`
+  (order 20 → 30); `summary` ≤ 70 chars (loader hard-fails otherwise).
+- `hug help :agents` still renders; its worktree section points to
+  `hug help :worktree` with no dangling reference and no duplicated ritual prose.
+- The `hug-worktree` skill loads in a skill-aware host and its body resolves to
+  the article (delegation, not a copy).
+- README install steps run clean (dry-run the curl + `cp -r`); zero `.skill`
+  references remain; all shipped skills listed.
+
+## Rollout
+
+Single hug-scm change (article + agents.md shrink + skill + README). No loader
+or command changes, so no migration and no version gate — the article is
+discoverable the moment the file lands.


### PR DESCRIPTION
✅ Ship the worktree ritual as a first-class hug article (\`hug help :worktree\`) plus a thin host-neutral skill, and collapse \`agents.md\` to a pointer. Before, the ritual lived as a cramped section in one guide; agents on any host got it at different depths.

🟢 Low risk: docs-only, drop-in for the existing glob-discovered article loader (no registration, no code changes).

More context: the article is the canonical home; the skill and \`agents.md\` both delegate, so the ritual has exactly one prose source and cannot drift.

<details><summary>What's in the change</summary>

- **NEW** \`git-config/lib/python/articles/worktree.md\` — the full worktree ritual (worktree-first, base off an up-to-date integration branch, work inside it, sanitize before finishing, clean up after merge, skip conditions, subagents). \`order = 30\` slots it right after \`agents\` (20) in \`hug help :\`.
- **MODIFIED** \`git-config/lib/python/articles/agents.md\` — the worktree section shrinks to the \`hug wt*\` command menu + a two-rule safety echo + the base-branch reminder + a \`hug help :worktree\` pointer. The duplicated prose and the old \"load the hug-worktree skill\" line are gone. Adds a \`:worktree\` cross-ref to \"Where to go next\".
- **NEW** \`docs/skills/hug-worktree/SKILL.md\` — a thin host-neutral skill that delegates to \`hug help :worktree\` (no ritual prose of its own, so it cannot drift). Skill-aware hosts get the affordance; non-skill agents get the same ritual straight from hug.
- **MODIFIED** \`docs/skills/README.md\` — fixes the stale install path (the old one-liner installed a single-file \`hug-workflow.skill\` bundle that never existed; real skills are directories). Directory-based \`cp -r\` install + a single-file \`curl\` form with a multi-file caveat. Lists all three shipped skills: \`hug-workflow\`, \`hug-worktree\`, \`hug-repo-analysis\` (the last was already shipping but undocumented).

</details>

🔁 Post-merge cascade: a downstream private config flips its \`hug-worktree\` skill directory to a relative symlink into this repo's \`docs/skills/hug-worktree\` once this lands on \`main\`. Tracked separately; no action needed in this PR.

## Test plan

- [ ] \`hug help :worktree\` renders the full ritual.
- [ ] \`hug help :\` lists \`worktree\` right after \`agents\`.
- [ ] \`hug help :agents\` still renders; its worktree section points to \`:worktree\` with no duplicated prose.
- [ ] \`docs/skills/hug-worktree/SKILL.md\` loads in a skill-aware host and delegates to the article.
- [ ] \`docs/skills/README.md\` install steps run clean (dry-run \`curl\` + \`cp -r\`); zero \`.skill\` references remain.