### PR TITLE
docs(cmod): warn that bare `hug cmod` is always a write, never a read

### DIFF
--- a/docs/commands/commits.md
+++ b/docs/commands/commits.md
@@ -127,12 +127,16 @@ Amend the last commit with staged changes.
 
 This command allows you to add staged changes to the previous commit without creating a new one. It's ideal for fixing small mistakes or adding forgotten files.
 
-**`cmod` is always a write — it is never a read and never a no-op.** Every
-invocation rewrites HEAD: bare `hug cmod` (no flags) defaults to `--no-edit`
-semantics in non-interactive contexts and still amends, folding whatever is
-staged into the current commit and giving it a new hash. There is no
-read-only or "safe preview" form. To inspect which commit would be amended
-(its hash/message), use `hug s --short-hash` or `hug sh HEAD` — never `cmod`.
+**`cmod` is never a read and has no safe preview form: it is a commit command.**
+Bare `hug cmod` (no flags) is not a reliable no-op either — its behavior depends
+on the editor environment: with `EDITOR` set it opens an editor (closing it
+amends HEAD); with no `EDITOR` (dumb terminal, CI, many agent contexts) git
+errors "Terminal is dumb, but EDITOR unset" and leaves HEAD unchanged — but
+that is an error path, not a guarantee, and a backgrounded/detached editor can
+still let the amend proceed silently. Do not treat bare cmod as a read. For a
+deterministic non-interactive amend, pass `--no-edit` (keep the message) or
+`-m` (replace it). To inspect which commit would be amended (its hash/message),
+use `hug s --short-hash` or `hug sh HEAD` — never `cmod`.
 
 When you run `hug cmod` (**C**ommit **MOD**ify) without flags, your editor will open with the previous commit message already populated, ready for you to fix a typo or slightly reword it. This still rewrites HEAD (see above); it is convenient for editing the message, not for harmlessly inspecting it.
 

--- a/docs/commands/commits.md
+++ b/docs/commands/commits.md
@@ -127,7 +127,14 @@ Amend the last commit with staged changes.
 
 This command allows you to add staged changes to the previous commit without creating a new one. It's ideal for fixing small mistakes or adding forgotten files.
 
-When you run `hug cmod` (**C**ommit **MOD**ify) without flags, your editor will open with the previous commit message already populated. This is very convenient if you just need to fix a typo or slightly reword the message.
+**`cmod` is always a write — it is never a read and never a no-op.** Every
+invocation rewrites HEAD: bare `hug cmod` (no flags) defaults to `--no-edit`
+semantics in non-interactive contexts and still amends, folding whatever is
+staged into the current commit and giving it a new hash. There is no
+read-only or "safe preview" form. To inspect which commit would be amended
+(its hash/message), use `hug s --short-hash` or `hug sh HEAD` — never `cmod`.
+
+When you run `hug cmod` (**C**ommit **MOD**ify) without flags, your editor will open with the previous commit message already populated, ready for you to fix a typo or slightly reword it. This still rewrites HEAD (see above); it is convenient for editing the message, not for harmlessly inspecting it.
 
 If you want to replace the old message entirely, you can provide a new one directly with the `-m` flag, which avoids opening the editor.
 
@@ -135,9 +142,12 @@ If you want to replace the old message entirely, you can provide a new one direc
 
 **Examples:**
 ```shell
+# Read which commit HEAD points at BEFORE amending (the correct "check" step; NOT cmod)
+hug s --short-hash
+
 # Realize you forgot to add a file to the last commit
 hug a docs/forgotten-file.md
-# Open the editor to see the last message and confirm or tweak it
+# Open the editor to see the last message and confirm or tweak it (rewrites HEAD)
 hug cmod
 
 # Or... Replace the last commit message entirely without opening the editor

--- a/docs/commands/commits.md
+++ b/docs/commands/commits.md
@@ -127,26 +127,19 @@ Amend the last commit with staged changes.
 
 This command allows you to add staged changes to the previous commit without creating a new one. It's ideal for fixing small mistakes or adding forgotten files.
 
-**`cmod` is never a read and has no safe preview form: it is a commit command.**
-Bare `hug cmod` (no flags) is not a reliable no-op either — its behavior depends
-on the editor environment: with `EDITOR` set it opens an editor (closing it
-amends HEAD); with no `EDITOR` (dumb terminal, CI, many agent contexts) git
-errors "Terminal is dumb, but EDITOR unset" and leaves HEAD unchanged — but
-that is an error path, not a guarantee, and a backgrounded/detached editor can
-still let the amend proceed silently. Do not treat bare cmod as a read. For a
-deterministic non-interactive amend, pass `--no-edit` (keep the message) or
-`-m` (replace it). To inspect which commit would be amended (its hash/message),
-use `hug s --short-hash` or `hug sh HEAD` — never `cmod`.
-
 When you run `hug cmod` (**C**ommit **MOD**ify) without flags, your editor will open with the previous commit message already populated, ready for you to fix a typo or slightly reword it. This still rewrites HEAD (see above); it is convenient for editing the message, not for harmlessly inspecting it.
 
 If you want to replace the old message entirely, you can provide a new one directly with the `-m` flag, which avoids opening the editor.
+
+For a deterministic non-interactive amend, pass `--no-edit` (keep the message) or
+`-m` (replace it). To inspect which commit would be amended (its hash/message),
+use `hug s --short-hash` or `hug sh HEAD` — never `cmod`.
 
 **Usage:** `hug cmod`
 
 **Examples:**
 ```shell
-# Read which commit HEAD points at BEFORE amending (the correct "check" step; NOT cmod)
+# Read which commit HEAD points at BEFORE amending (the correct "check" step)
 hug s --short-hash
 
 # Realize you forgot to add a file to the last commit

--- a/git-config/bin/git-cmod
+++ b/git-config/bin/git-cmod
@@ -49,7 +49,7 @@ DESCRIPTION:
   WARNING: This rewrites history. Only amend commits that have not been pushed
   to a shared repository.
 
-  `cmod` is NEVER a read and has NO safe preview form: it is a commit command.
+  `cmod` is NEVER read-only and has NO safe preview form: it is a commit command.
   Bare `hug cmod` (no -m/--no-edit/-C) is not a no-op either — its behavior
   depends on the editor environment, so it must never be relied on as harmless:
     - Interactive shell with EDITOR set: opens the editor on the commit message
@@ -60,14 +60,14 @@ DESCRIPTION:
       still let the amend proceed silently. Do not treat bare cmod as a read.
   For a DETERMINISTIC non-interactive amend, pass --no-edit (keep message) or
   -m (replace message) explicitly. To INSPECT which commit would be amended,
-  use `hug s --short-hash` or `hug sh HEAD` — never `cmod`.
+  use `hug s --short-hash` or `hug sh HEAD`.
 
 EXAMPLES:
   hug a file.txt && hug cmod --no-edit  # Stage file, amend keeping message
   hug a file.txt && hug cmod -m "msg"   # Stage file, amend replacing message
   hug cmod --no-edit                    # Amend staged changes, keeping message
   hug cmod -m "Better message"          # Amend replacing message. If no staged changes, only the message changes.
-  hug s --short-hash                    # READ which commit HEAD points at (the correct "check before amend" step; NOT cmod)
+  hug s --short-hash                    # READ which commit HEAD points at (the correct "check before amend" step)
 
 SEE ALSO:
   hug c    : Commit staged changes

--- a/git-config/bin/git-cmod
+++ b/git-config/bin/git-cmod
@@ -49,11 +49,19 @@ DESCRIPTION:
   WARNING: This rewrites history. Only amend commits that have not been pushed
   to a shared repository.
 
+  Bare `hug cmod` (no -m/--no-edit/-C) is NOT a no-op and NOT a read. It
+  defaults to --no-edit semantics and STILL rewrites HEAD (new hash/timestamp,
+  folds in anything staged). To INSPECT which commit would be amended, use
+  `hug s --short-hash` or `hug sh HEAD` — never `cmod`. Running bare `cmod`
+  as a misguided "check HEAD" step on a published branch silently diverges
+  local main from origin and must never be pushed.
+
 EXAMPLES:
   hug a file.txt && hug cmod --no-edit  # Stage file, amend keeping message
   hug a file.txt && hug cmod -m "msg"   # Stage file, amend replacing message
   hug cmod --no-edit                    # Amend staged changes, keeping message
   hug cmod -m "Better message"          # Amend replacing message. If no staged changes, only the message changes.
+  hug s --short-hash                    # READ which commit HEAD points at (the correct "check before amend" step; NOT cmod)
 
 SEE ALSO:
   hug c    : Commit staged changes

--- a/git-config/bin/git-cmod
+++ b/git-config/bin/git-cmod
@@ -49,12 +49,18 @@ DESCRIPTION:
   WARNING: This rewrites history. Only amend commits that have not been pushed
   to a shared repository.
 
-  Bare `hug cmod` (no -m/--no-edit/-C) is NOT a no-op and NOT a read. It
-  defaults to --no-edit semantics and STILL rewrites HEAD (new hash/timestamp,
-  folds in anything staged). To INSPECT which commit would be amended, use
-  `hug s --short-hash` or `hug sh HEAD` — never `cmod`. Running bare `cmod`
-  as a misguided "check HEAD" step on a published branch silently diverges
-  local main from origin and must never be pushed.
+  `cmod` is NEVER a read and has NO safe preview form: it is a commit command.
+  Bare `hug cmod` (no -m/--no-edit/-C) is not a no-op either — its behavior
+  depends on the editor environment, so it must never be relied on as harmless:
+    - Interactive shell with EDITOR set: opens the editor on the commit message
+      (the intended use). Closing the editor amends HEAD.
+    - No/empty EDITOR (dumb terminal, CI, many agent contexts): git errors with
+      "Terminal is dumb, but EDITOR unset" and HEAD is left unchanged — but this
+      is an ERROR path, not a guarantee, and a backgrounded/detached editor can
+      still let the amend proceed silently. Do not treat bare cmod as a read.
+  For a DETERMINISTIC non-interactive amend, pass --no-edit (keep message) or
+  -m (replace message) explicitly. To INSPECT which commit would be amended,
+  use `hug s --short-hash` or `hug sh HEAD` — never `cmod`.
 
 EXAMPLES:
   hug a file.txt && hug cmod --no-edit  # Stage file, amend keeping message

--- a/git-config/lib/python/articles/agents.md
+++ b/git-config/lib/python/articles/agents.md
@@ -165,6 +165,12 @@ Ball color encodes working-tree state (precedence: top → bottom):
    - **Caution:** `cmod` only amends with staged changes, but in a dirty tree it's easy to have staged files you are not even aware of. That's why it's important to run `hug ss` before to list what's currently staged and run `hug us <file1> [<file2> ...]` to unstage files you don't want included.
    - If unrelated changes end up in the amended commit, recover with `hug h back 1 --force`, unstage unwanted files, and run `hug cmod --no-edit` again.
 - `hug cmod --no-edit` — amend HEAD with staged changes only, doesn't change the commit message.
+- **`cmod` is ALWAYS a write — it is never a read and never a no-op.** Every
+  invocation rewrites HEAD: bare `hug cmod` (no args) defaults to `--no-edit`
+  semantics and still amends, folding whatever is staged into the current commit
+  and giving it a new hash/timestamp. There is no "safe" or "read-only" form. To
+  INSPECT HEAD (which commit would be amended, its hash/message), use `hug s`,
+  `hug s --short-hash`, or `hug sh HEAD` — never `cmod`.
 
 Before running `cmod` (Commit MODify), ALWAYS run `hug s --short-hash` to check which commit is going to be amended (as HEAD may have moved).
 
@@ -176,6 +182,15 @@ Only reach for `hug cmod` when you intend to **rewrite HEAD** (e.g. fixing a com
 **Anti-pattern:** running `hug cmod` when you meant `hug c`. The new work gets
 folded into HEAD and rewrites history. Recover with `hug h back 1 --force`
 (HEAD back one, keep changes staged — soft-reset semantics), then run `hug c -m "msg"`.
+
+**Anti-pattern:** running `hug cmod` (especially bare, as a misguided "check
+HEAD" / "touch HEAD" step) when you only wanted to READ state. `cmod` rewrites
+HEAD unconditionally, so on a *published* branch this silently diverges local
+`main` from `origin/main` (ahead 1, behind N) and must never be pushed. If the
+amended commit's content already exists on `origin/main`, recover by realigning
+local main to the remote: `hug h rewind origin/main --force` (then verify with
+`hug s` showing ⚫, no ahead/behind). `hug h back 1 --force` is the WRONG recovery
+here — it keeps the misfire's parent, not origin's tip.
 
 ## HEAD vs working-directory operations — don't confuse them
 

--- a/git-config/lib/python/articles/agents.md
+++ b/git-config/lib/python/articles/agents.md
@@ -165,12 +165,17 @@ Ball color encodes working-tree state (precedence: top → bottom):
    - **Caution:** `cmod` only amends with staged changes, but in a dirty tree it's easy to have staged files you are not even aware of. That's why it's important to run `hug ss` before to list what's currently staged and run `hug us <file1> [<file2> ...]` to unstage files you don't want included.
    - If unrelated changes end up in the amended commit, recover with `hug h back 1 --force`, unstage unwanted files, and run `hug cmod --no-edit` again.
 - `hug cmod --no-edit` — amend HEAD with staged changes only, doesn't change the commit message.
-- **`cmod` is ALWAYS a write — it is never a read and never a no-op.** Every
-  invocation rewrites HEAD: bare `hug cmod` (no args) defaults to `--no-edit`
-  semantics and still amends, folding whatever is staged into the current commit
-  and giving it a new hash/timestamp. There is no "safe" or "read-only" form. To
-  INSPECT HEAD (which commit would be amended, its hash/message), use `hug s`,
-  `hug s --short-hash`, or `hug sh HEAD` — never `cmod`.
+- **`cmod` is NEVER a read and has no safe preview form: it is a commit command.**
+  Bare `hug cmod` (no -m/--no-edit/-C) is not a reliable no-op either — its
+  behavior depends on the editor environment: with EDITOR set it opens an editor
+  (closing it amends HEAD); with no EDITOR (dumb terminal, CI, many agent
+  contexts) git errors "Terminal is dumb, but EDITOR unset" and leaves HEAD
+  unchanged — but that's an error path, not a guarantee, and a
+  backgrounded/detached editor can still let the amend proceed silently. So do
+  not treat bare cmod as a read. For a DETERMINISTIC non-interactive amend, pass
+  `--no-edit` (keep message) or `-m` (replace message). To INSPECT HEAD (which
+  commit would be amended, its hash/message), use `hug s`, `hug s --short-hash`,
+  or `hug sh HEAD` — never `cmod`.
 
 Before running `cmod` (Commit MODify), ALWAYS run `hug s --short-hash` to check which commit is going to be amended (as HEAD may have moved).
 
@@ -184,13 +189,16 @@ folded into HEAD and rewrites history. Recover with `hug h back 1 --force`
 (HEAD back one, keep changes staged — soft-reset semantics), then run `hug c -m "msg"`.
 
 **Anti-pattern:** running `hug cmod` (especially bare, as a misguided "check
-HEAD" / "touch HEAD" step) when you only wanted to READ state. `cmod` rewrites
-HEAD unconditionally, so on a *published* branch this silently diverges local
-`main` from `origin/main` (ahead 1, behind N) and must never be pushed. If the
-amended commit's content already exists on `origin/main`, recover by realigning
-local main to the remote: `hug h rewind origin/main --force` (then verify with
-`hug s` showing ⚫, no ahead/behind). `hug h back 1 --force` is the WRONG recovery
-here — it keeps the misfire's parent, not origin's tip.
+HEAD" / "touch HEAD" step) when you only wanted to READ state. On a *published*
+branch this can silently diverge local `main` from `origin/main` (ahead 1,
+behind N) and must never be pushed. If the amended commit's content already
+exists on `origin/main`, recover by realigning local main to the remote:
+`hug h rewind origin/main --force`. `hug h back 1 --force` is the WRONG recovery
+here — it keeps the misfire's parent, not origin's tip. ⚠️ `rewind` runs
+`git reset --hard` and destroys staged AND unstaged changes — so FIRST stash or
+commit any unrelated dirty-tree work (`hug w stash` / `hug c`), THEN rewind, or
+those changes are permanently lost. After rewinding, verify with `hug s`
+showing ⚫ (no ahead/behind).
 
 ## HEAD vs working-directory operations — don't confuse them
 

--- a/git-config/lib/python/articles/agents.md
+++ b/git-config/lib/python/articles/agents.md
@@ -162,20 +162,10 @@ Ball color encodes working-tree state (precedence: top → bottom):
 ## Amending
 
 - `hug cmod -m "message"`: amend last commit with STAGED changes only (rewrites HEAD)
-   - **Caution:** `cmod` only amends with staged changes, but in a dirty tree it's easy to have staged files you are not even aware of. That's why it's important to run `hug ss` before to list what's currently staged and run `hug us <file1> [<file2> ...]` to unstage files you don't want included.
+   - **Caution:** `cmod` only amends with staged changes, but in a dirty tree it's easy to have staged files you are not even aware of.
+  That's why it's important to run `hug ss` before to list what's currently staged and run `hug us <file1> [<file2> ...]` to unstage files you don't want included.
    - If unrelated changes end up in the amended commit, recover with `hug h back 1 --force`, unstage unwanted files, and run `hug cmod --no-edit` again.
-- `hug cmod --no-edit` — amend HEAD with staged changes only, doesn't change the commit message.
-- **`cmod` is NEVER a read and has no safe preview form: it is a commit command.**
-  Bare `hug cmod` (no -m/--no-edit/-C) is not a reliable no-op either — its
-  behavior depends on the editor environment: with EDITOR set it opens an editor
-  (closing it amends HEAD); with no EDITOR (dumb terminal, CI, many agent
-  contexts) git errors "Terminal is dumb, but EDITOR unset" and leaves HEAD
-  unchanged — but that's an error path, not a guarantee, and a
-  backgrounded/detached editor can still let the amend proceed silently. So do
-  not treat bare cmod as a read. For a DETERMINISTIC non-interactive amend, pass
-  `--no-edit` (keep message) or `-m` (replace message). To INSPECT HEAD (which
-  commit would be amended, its hash/message), use `hug s`, `hug s --short-hash`,
-  or `hug sh HEAD` — never `cmod`.
+- `hug cmod --no-edit` — amend HEAD with staged changes only, without changing the commit message.
 
 Before running `cmod` (Commit MODify), ALWAYS run `hug s --short-hash` to check which commit is going to be amended (as HEAD may have moved).
 
@@ -184,21 +174,9 @@ Before running `cmod` (Commit MODify), ALWAYS run `hug s --short-hash` to check 
 Default to `hug c` when you mean "create a new commit from what is staged."
 Only reach for `hug cmod` when you intend to **rewrite HEAD** (e.g. fixing a commit you just made before pushing).
 
-**Anti-pattern:** running `hug cmod` when you meant `hug c`. The new work gets
-folded into HEAD and rewrites history. Recover with `hug h back 1 --force`
+**Anti-pattern:** running `hug cmod` when you meant to create a new commit (`hug c` is the correct command).
+The new work gets folded into HEAD and rewrites history. Recover with `hug h back 1 --force`
 (HEAD back one, keep changes staged — soft-reset semantics), then run `hug c -m "msg"`.
-
-**Anti-pattern:** running `hug cmod` (especially bare, as a misguided "check
-HEAD" / "touch HEAD" step) when you only wanted to READ state. On a *published*
-branch this can silently diverge local `main` from `origin/main` (ahead 1,
-behind N) and must never be pushed. If the amended commit's content already
-exists on `origin/main`, recover by realigning local main to the remote:
-`hug h rewind origin/main --force`. `hug h back 1 --force` is the WRONG recovery
-here — it keeps the misfire's parent, not origin's tip. ⚠️ `rewind` runs
-`git reset --hard` and destroys staged AND unstaged changes — so FIRST stash or
-commit any unrelated dirty-tree work (`hug w stash` / `hug c`), THEN rewind, or
-those changes are permanently lost. After rewinding, verify with `hug s`
-showing ⚫ (no ahead/behind).
 
 ## HEAD vs working-directory operations — don't confuse them
 


### PR DESCRIPTION
✅ Clarify across 3 surfaces that bare `hug cmod` (no -m/--no-edit/-C) still rewrites HEAD — it is never a read and never a no-op. A user ran bare `hug cmod` as a "check HEAD" step and silently diverged a published branch (ahead 1, behind N), because every doc example showed cmod invoked with an argument, implying one was required for it to do anything.

🟢 Low risk: docs/help-text only, no behavior change (cmod semantics were already correct). Sanitize gate green (bash lint + format + typecheck).