### PR TITLE
fix: #229 Phase 1 — count_commits_in_range audit (kill the == 0 ⟹ aligned idiom)

### DIFF
--- a/git-config/bin/git-cmv
+++ b/git-config/bin/git-cmv
@@ -158,15 +158,15 @@ target=$(git rev-parse "$target")
 
 # Early calculation for commits to relocate (for 0-commit early exit and prompts).
 # cmv's target MUST be an ancestor ("specific commit to move above", "reset branch back"),
-# so == 0 is the correct vacuous-op no-op — do NOT migrate this to is_aligned (a forward
+# so == 0 is the correct vacuous-op no-op — do NOT migrate this to is_same_commit (a forward
 # target is an incoherent cmv request, and falling through would hard-reset the branch
 # FORWARD + switch branch on a 'NOT RESTORABLE' command). Strict: a bad ref now fails
 # loudly instead of masquerading as '0 commits'. The OLD message lied ('already at target')
-# for a descendant target; branch on is_aligned so BOTH sub-cases are truthful (a commit is
+# for a descendant target; branch on is_same_commit so BOTH sub-cases are truthful (a commit is
 # its own ancestor — equality-as-ancestry — so 'is not an ancestor' would lie when aligned).
 commits_to_relocate=$(count_commits_in_range "$target" HEAD) || exit 1
 if [ "$commits_to_relocate" -eq 0 ]; then
-  if is_aligned "$target" HEAD; then
+  if is_same_commit "$target" HEAD; then
     info "No commits to move (already at $(git rev-parse --short "$target"))."
   else
     info "No commits to move (target $(git rev-parse --short "$target") is a descendant of HEAD; cmv needs an ancestor target)."

--- a/git-config/bin/git-cmv
+++ b/git-config/bin/git-cmv
@@ -156,10 +156,21 @@ fi
 # Resolve target to actual SHA (important: do this before reset changes HEAD)
 target=$(git rev-parse "$target")
 
-# Early calculation for commits to relocate (for 0-commit early exit and prompts)
-commits_to_relocate=$(count_commits_in_range "$target" HEAD)
+# Early calculation for commits to relocate (for 0-commit early exit and prompts).
+# cmv's target MUST be an ancestor ("specific commit to move above", "reset branch back"),
+# so == 0 is the correct vacuous-op no-op — do NOT migrate this to is_aligned (a forward
+# target is an incoherent cmv request, and falling through would hard-reset the branch
+# FORWARD + switch branch on a 'NOT RESTORABLE' command). Strict: a bad ref now fails
+# loudly instead of masquerading as '0 commits'. The OLD message lied ('already at target')
+# for a descendant target; branch on is_aligned so BOTH sub-cases are truthful (a commit is
+# its own ancestor — equality-as-ancestry — so 'is not an ancestor' would lie when aligned).
+commits_to_relocate=$(count_commits_in_range "$target" HEAD) || exit 1
 if [ "$commits_to_relocate" -eq 0 ]; then
-  info "No commits to move (already at target)."
+  if is_aligned "$target" HEAD; then
+    info "No commits to move (already at $(git rev-parse --short "$target"))."
+  else
+    info "No commits to move (target $(git rev-parse --short "$target") is a descendant of HEAD; cmv needs an ancestor target)."
+  fi
   exit 0
 fi
 commit_word="commit"

--- a/git-config/bin/git-h-back
+++ b/git-config/bin/git-h-back
@@ -102,10 +102,11 @@ else
       git diff --stat --root HEAD >&2
     fi
 
-    # Root-commit path stays DANGER (spec §6): recovery at root is a guaranteed
-    # no-op (unborn HEAD ⇒ rev-list fails ⇒ count 0), so there is no complete
-    # recovery to license a warn tier. The non-root path below is warn because
-    # --soft preserves all work; this root path must NOT be swept along with it.
+    # Root-commit path stays DANGER (spec §6): recovery at root is a guaranteed LOUD FAILURE
+    # post-#229-Phase-1 (unborn HEAD ⇒ the now-strict rev-list propagates non-zero ⇒ the
+    # mover exits ≠ 0), so there is still no complete recovery to license a warn tier. The
+    # non-root path below is warn because --soft preserves all work; this root path must NOT
+    # be swept along with it.
     if [[ ${HUG_FORCE:-} != true ]] && has_staged_changes; then
       prompt_confirm_danger "back" "Rewrites history by undoing root commit"
     fi

--- a/git-config/bin/git-h-files
+++ b/git-config/bin/git-h-files
@@ -119,7 +119,10 @@ check_git_repo
 if $upstream; then
   start_point=$(get_upstream_commit) # This will exit if no upstream
   range="$start_point..HEAD"
-  local_commits=$(count_commits_in_range "$start_point" HEAD)
+  # Explicit '|| exit 1': belt-and-suspenders (set -e already exits on a failing
+  # top-level assignment). NOTE: this is script top level inside the `if` block —
+  # do NOT add 'local' here; 'local' outside a function is a fatal error.
+  local_commits=$(count_commits_in_range "$start_point" HEAD) || exit 1
   if [ "$local_commits" -eq 0 ]; then
     info "No local-only commits; already synced to upstream."
     exit 0

--- a/git-config/bin/git-h-files
+++ b/git-config/bin/git-h-files
@@ -199,7 +199,7 @@ if $upstream; then
 elif [[ -n "$temporal_spec" ]]; then
   start_point_short=$(git rev-parse --short "$start_point")
   start_point_date=$(git log -1 --format="%ci" "$start_point" | cut -d' ' -f1)
-  num_commits=$(count_commits_in_range "$start_point" HEAD)
+  num_commits=$(count_commits_in_range_or_zero "$start_point" HEAD)
   tip "These $count files and their stats were changed in $num_commits commits since '$temporal_spec' (first commit: $start_point_short from $start_point_date)."
 else
   tip "These $count files and their stats would be affected by moving HEAD to $start_point (e.g., via 'h back' or 'h rewind')."

--- a/git-config/bin/git-h-restore
+++ b/git-config/bin/git-h-restore
@@ -15,9 +15,9 @@ set -euo pipefail
 #
 # WHY this exists: an explicit recovery primitive that resets HEAD to a target commit as
 # the inverse of a HEAD-mover (h-back/h-undo/h-rollback/h-rewind). Its no-op test is EXACT
-# SHA equality (via is_aligned) — the only test that distinguishes "already there" from
+# SHA equality (via is_same_commit) — the only test that distinguishes "already there" from
 # "move to a different commit," including a FORWARD move to a descendant. The movers now
-# share this same is_aligned gate (hug-git-upstream), so re-invoking a mover to recover is
+# share this same is_same_commit gate (hug-git-upstream), so re-invoking a mover to recover is
 # no longer a special case; this command remains the dedicated, op-named inverse.
 #
 # Design decisions:
@@ -103,11 +103,11 @@ esac
 # Resolve target.  target_arg is required — ${target_arg:?} fails helpfully.
 target=$(resolve_target_with_temporal "" "" "${target_arg:?target required}" '') || exit 1
 
-# The defining feature: no-op ONLY on exact SHA equality (via is_aligned), never a
-# range-count gate. The movers now share this same is_aligned gate (hug-git-upstream), so
-# recovery and the movers agree on what 'already there' means; is_aligned (unlike a
+# The defining feature: no-op ONLY on exact SHA equality (via is_same_commit), never a
+# range-count gate. The movers now share this same is_same_commit gate (hug-git-upstream), so
+# recovery and the movers agree on what 'already there' means; is_same_commit (unlike a
 # one-directional count == 0) distinguishes 'aligned' from 'need to move forward'.
-if is_aligned "$target" HEAD; then
+if is_same_commit "$target" HEAD; then
   info "Already at $(git rev-parse --short "$target"). Nothing to restore."
   exit 0
 fi

--- a/git-config/bin/git-h-restore
+++ b/git-config/bin/git-h-restore
@@ -13,19 +13,21 @@ set -euo pipefail
 #
 # git-h-restore — the recovery primitive.
 #
-# WHY this exists: re-invoking a mover (h-back/h-undo/h-rollback/h-rewind) to
-# recover forward no-ops via handle_standard_operation's count==0 gate (the
-# aligned-target short-circuit in hug-git-upstream:109-112).  Recovery requires
-# a purpose-built reset whose no-op test is EXACT SHA EQUALITY — the only test
-# that distinguishes "already there" from "need to move FORWARD to a descendant."
+# WHY this exists: an explicit recovery primitive that resets HEAD to a target commit as
+# the inverse of a HEAD-mover (h-back/h-undo/h-rollback/h-rewind). Its no-op test is EXACT
+# SHA equality (via is_aligned) — the only test that distinguishes "already there" from
+# "move to a different commit," including a FORWARD move to a descendant. The movers now
+# share this same is_aligned gate (hug-git-upstream), so re-invoking a mover to recover is
+# no longer a special case; this command remains the dedicated, op-named inverse.
 #
 # Design decisions:
 #   - Op-named flags (--back/--undo/--rollback/--rewind) select the reset MODE;
 #     the flag DOES NOT encode direction.  Direction comes solely from target
 #     vs HEAD.
 #   - No-op only on exact SHA match (never the range-count gate).
-#   - Warn-tier prompt by default; safety additions (bare-numeric guard,
-#     --rewind+dirty danger escalation, per-tier prompt) arrive in Task 8.
+#   - Warn-tier prompt by default. Safety additions are in place: the bare-numeric
+#     guard (below), the --rewind+dirty tier=danger escalation, and the per-tier
+#     warn/danger prompt dispatch (the case "$tier" block in the confirmation below).
 
 show_help() {
   cat << EOF
@@ -101,10 +103,11 @@ esac
 # Resolve target.  target_arg is required — ${target_arg:?} fails helpfully.
 target=$(resolve_target_with_temporal "" "" "${target_arg:?target required}" '') || exit 1
 
-# The defining feature: no-op ONLY on exact SHA equality, never the range-count
-# gate.  This lets recovery move FORWARD to a descendant (re-invoking the mover
-# no-ops there via handle_standard_operation's count==0 bailout).
-if [ "$target" = "$(git rev-parse HEAD)" ]; then
+# The defining feature: no-op ONLY on exact SHA equality (via is_aligned), never a
+# range-count gate. The movers now share this same is_aligned gate (hug-git-upstream), so
+# recovery and the movers agree on what 'already there' means; is_aligned (unlike a
+# one-directional count == 0) distinguishes 'aligned' from 'need to move forward'.
+if is_aligned "$target" HEAD; then
   info "Already at $(git rev-parse --short "$target"). Nothing to restore."
   exit 0
 fi

--- a/git-config/bin/git-h-squash
+++ b/git-config/bin/git-h-squash
@@ -164,7 +164,10 @@ if $upstream; then
   target=$(resolve_target_with_temporal "$upstream" "$temporal_spec" "$target_arg" 'HEAD~2') || exit 1
   target=$(handle_upstream_operation "squashing" "$tier" "back" "discards local-only commits") || exit $?
   [[ -z "${target:-}" ]] && exit 0
-  commits_to_squash=$(count_commits_in_range "$target" HEAD)
+  # Explicit '|| exit 1': belt-and-suspenders (set -e already exits on a failing
+  # top-level assignment). No '== 0' test here by design — the upstream no-op
+  # decision lives inside handle_upstream_operation, not at this count site.
+  commits_to_squash=$(count_commits_in_range "$target" HEAD) || exit 1
 else
   # Use DRY helper for validation and target resolution
   target_commit=$(resolve_target_with_temporal "$upstream" "$temporal_spec" "$target_arg" 'HEAD~2') || exit 1
@@ -173,7 +176,11 @@ else
   ensure_ancestor_of_head "$target_commit" "cannot squash onto it."
   log_range="$target_commit"..HEAD
   target_display=$(git rev-parse --short "$target_commit" 2> /dev/null || echo "$target_commit")
-  commits_to_squash=$(count_commits_in_range "$target_commit" HEAD)
+  # Explicit '|| exit 1': belt-and-suspenders (set -e already exits on a failing
+  # top-level assignment). The '== 0' branch below is LIVE, not dead code:
+  # merge-base --is-ancestor treats EQUALITY as ancestry, so 'h squash <SHA-of-HEAD>'
+  # reaches it ("No commits to squash", exit 0, no commit). Pinned in test_head.bats.
+  commits_to_squash=$(count_commits_in_range "$target_commit" HEAD) || exit 1
   if [ "$commits_to_squash" -eq 0 ]; then
     info "No commits to squash (already at $target_display)."
     exit 0

--- a/git-config/bin/git-h-undo
+++ b/git-config/bin/git-h-undo
@@ -120,11 +120,11 @@ else
       info "No staged or unstaged changes detected; skipping confirmation."
     fi
 
-    # Root-commit path stays DANGER (spec §6): same root-commit reasoning as
-    # h-back — at root, recovery is a guaranteed no-op (unborn HEAD), so there
-    # is no complete recovery to license a warn tier. The non-root path below
-    # is warn because --mixed preserves all work; this root path must NOT be
-    # swept along with it.
+    # Root-commit path stays DANGER (spec §6): same root-commit reasoning as h-back — at
+    # root, recovery is a guaranteed LOUD FAILURE (unborn HEAD ⇒ strict rev-list propagates
+    # non-zero ⇒ mover exits ≠ 0), so there is no complete recovery to license a warn tier.
+    # The non-root path below is warn because --mixed preserves all work; this root path
+    # must NOT be swept along with it.
     if $should_prompt; then
       prompt_confirm_danger "undo" "Rewrites history by undoing root commit"
     fi

--- a/git-config/bin/git-log-outgoing
+++ b/git-config/bin/git-log-outgoing
@@ -89,7 +89,11 @@ else
   target_short=$(git rev-parse --short "$target")
 fi
 
-local_commits=$(count_commits_in_range "$target" HEAD)
+# Explicit '|| exit 1': this is script top level under `set -e`, which already
+# exits on a failing bare assignment, so this is belt-and-suspenders — it
+# normalizes the exit code and keeps the strict propagation obvious to a future
+# reader (and safe against a later `set +e`). Not a behavior change on valid refs.
+local_commits=$(count_commits_in_range "$target" HEAD) || exit 1
 
 if [ "$local_commits" -eq 0 ]; then
   info "No outgoing changes (already synced to $target_short)."

--- a/git-config/lib/README.md
+++ b/git-config/lib/README.md
@@ -96,7 +96,7 @@ The main `hug-git-kit` file sources all these modules to maintain backward compa
   - **Two-predicate dirty-detection model**: Hug uses two distinct predicates for different decision points:
     - `has_uncommitted_tracked_changes` -- tracked-only (staged + unstaged), excludes untracked. Used for **tier/safety decisions** AND for the **aligned-target gating** in `handle_standard_operation` (the skip-when-aligned decision), because no reset mode (`--soft`/`--mixed`/`--keep`/`--hard`) touches untracked files, so untracked files are irrelevant to safety.
     - `has_untracked_or_pending_changes` (renamed from `has_pending_changes`) -- tracked + untracked (the broadest dirtiness predicate). Used where untracked files matter contextually (e.g. `git-caa`, `git-rb`, `git-w-wip`) -- NOT for the aligned-target gate, which uses the tracked-only predicate above.
-    - **Alignment vs. dirtiness:** alignment itself (whether two refs resolve to the same commit) is tested with `is_aligned` -- NEVER with `count_commits_in_range … == 0` (which also reads `0` when one ref is *behind*). See the "Range counting" subsection under Commit Range Analysis.
+    - **Alignment vs. dirtiness:** alignment itself (whether two refs resolve to the same commit) is tested with `is_same_commit` -- NEVER with `count_commits_in_range … == 0` (which also reads `0` when one ref is *behind*). See the "Range counting" subsection under Commit Range Analysis.
   - Other state checks: `has_staged_changes`, `has_unstaged_changes`
 - Cleanliness validation (`check_working_tree_clean`, `check_files_clean`)
 - File state checking (`check_file_in_commit`, `check_file_staged`, `check_file_unstaged`)
@@ -125,14 +125,14 @@ The main `hug-git-kit` file sources all these modules to maintain backward compa
 
 #### hug-git-commit
 - Count commits in range (`count_commits_in_range` strict, `count_commits_in_range_or_zero` display-only)
-- Ahead/behind relationship and alignment (`commits_ahead_behind`, `is_aligned`) -- see "Range counting" below
+- Identity and signed distance (`is_same_commit`, `commit_offset`) -- see "Range counting" below
 - List changed files (`list_changed_files_in_range`, `count_changed_files_in_range`)
 - Print commit lists (`print_commit_list_in_range`)
 - Preview helpers (`print_preview_summary`, `print_commit_list_header`)
 
 #### hug-git-upstream
 - Handle upstream operations (`handle_upstream_operation`) -- takes a required `tier` parameter (warn/danger) for the upstream confirmation path. This closes the inverted confirmation gradient: previously every upstream path was gated at warn regardless of the operation's actual danger level.
-- Handle standard operations (`handle_standard_operation`) -- aligned-target gating uses `has_uncommitted_tracked_changes` (tracked-only) for the skip-when-aligned decision. Alignment itself is tested with `is_aligned` (exact SHA equality), NEVER a one-directional `count_commits_in_range … == 0` -- see the "Range counting" subsection. Callers invoke this helper BARE (not via `$(…)`) so its aligned-path `exit 0` terminates the mover.
+- Handle standard operations (`handle_standard_operation`) -- aligned-target gating uses `has_uncommitted_tracked_changes` (tracked-only) for the skip-when-aligned decision. Alignment itself is tested with `is_same_commit` (exact SHA equality), NEVER a one-directional `count_commits_in_range … == 0` -- see the "Range counting" subsection. Callers invoke this helper BARE (not via `$(…)`) so its aligned-path `exit 0` terminates the mover.
 - Recovery hint helper (`emit_head_recovery_hint`) -- emits the `hug h restore <SHA> --<op> -y` recovery command to stderr after a successful warn-tier HEAD-mover. Suppressed under `HUG_QUIET=T`. Used by h-back, h-undo, h-rollback, h-rewind (warn), and h-squash.
 - See also: `git-h-restore` -- the recovery primitive that `emit_head_recovery_hint` prints. Uses exact-SHA no-op (never the range-count gate) so it can move HEAD forward to a descendant commit.
 
@@ -428,16 +428,20 @@ print_commit_list_in_range "origin/main" "HEAD"
 
 - **`count_commits_in_range "start" ["end"]`** -- a ONE-DIRECTIONAL ahead-count: how far
   `end` is ahead of `start`. A result of `0` means "`end` is NOT ahead of `start`" — which
-  is true BOTH when `end == start` (aligned) AND when `end` is *behind* `start`. **Never
+  is true BOTH when `end == start` (identity) AND when `end` is *behind* `start`. **Never
   treat `0` as "aligned."** STRICT: a failed `rev-list` (invalid ref, unborn HEAD)
   propagates non-zero — it is NOT swallowed into `0`; callers must handle failure.
-- **`commits_ahead_behind "start" "end"`** -- the full relationship as `"<behind>\t<ahead>"`
-  (git's native `--left-right` order: the FIRST arg's exclusive count comes FIRST). `0\t0`
-  ⟺ aligned. Parse into POSITIONAL fields; never `read ahead behind <<< "…"` (that swaps
-  them, since the name order ≠ output order). Both counts > 0 ⟺ the refs have diverged.
-- **`is_aligned "a" "b"`** -- the ONLY sanctioned alignment test (exit 0 iff `a` and `b`
-  resolve to the same commit). Use this wherever you would otherwise write
-  `count_commits_in_range … == 0` to mean "aligned."
+- **`is_same_commit "a" "b"`** -- the ONLY sanctioned identity test. A minimal pure-boolean
+  predicate (exit 0 iff `a` and `b` resolve to the same commit) implemented via `git
+  rev-parse --verify --quiet …^{commit}` SHA equality -- NO `rev-list` traversal. Use this
+  wherever you would otherwise write `count_commits_in_range … == 0` to mean "same commit."
+  It is shallow-safe (rev-parse only resolves refs; it does not walk the graph).
+- **`commit_offset "a" ["b"]`** -- signed distance from `a` to `b` (default `HEAD`).
+  `0` means IDENTITY (short-circuited on SHA equality), NOT merely "not ahead." Positive
+  `N` = `b` is ahead of `a` (clean forward distance); negative `-N` = `b` is behind `a`
+  (forward target / recovery direction). Diverged ⟹ empty stdout + exit 2 (so the
+  false-zero is unrepresentable by construction). Unresolvable ref ⟹ empty stdout + exit 3.
+  Use this when a caller also needs direction/magnitude, not just yes/no.
 - **`count_commits_in_range_or_zero`** -- display-only twin: a cosmetic `0` on rev-list
   failure, for rendered plans / tip text only. NEVER for a branching or alignment decision.
   This is the single sanctioned `echo 0`-on-failure swallow — it appears nowhere else
@@ -461,12 +465,12 @@ target=$(resolve_head_target "$1")
 # Called BARE (a plain command, NOT $(…)): when HEAD is already at $target its
 # aligned-guard runs `exit 0`, terminating the whole mover. That guard depends on the
 # bare call -- do NOT capture this helper via $(…) or the exit is swallowed. Alignment
-# is tested with is_aligned (exact SHA), never a one-directional count == 0.
+# is tested with is_same_commit (exact SHA), never a one-directional count == 0.
 handle_standard_operation "moving back" "$target"
 prompt_confirm_warn "Proceed? [y/N]: "   # mover confirms AFTER the helper's preview
 
-# Alignment test -- the ONLY sanctioned way to ask "same commit?":
-if is_aligned "$target" HEAD; then
+# Identity test -- the ONLY sanctioned way to ask "same commit?":
+if is_same_commit "$target" HEAD; then
     info "Already at target; nothing to do."
 fi
 

--- a/git-config/lib/README.md
+++ b/git-config/lib/README.md
@@ -94,8 +94,9 @@ The main `hug-git-kit` file sources all these modules to maintain backward compa
 #### hug-git-state
 - Working tree state checks:
   - **Two-predicate dirty-detection model**: Hug uses two distinct predicates for different decision points:
-    - `has_uncommitted_tracked_changes` -- tracked-only (staged + unstaged), excludes untracked. Used for **tier/safety decisions** because no reset mode (`--soft`/`--mixed`/`--keep`/`--hard`) touches untracked files, so untracked files are irrelevant to safety.
-    - `has_untracked_or_pending_changes` (renamed from `has_pending_changes`) -- tracked + untracked. Used for **aligned-target gating** in `handle_standard_operation` where untracked files matter contextually.
+    - `has_uncommitted_tracked_changes` -- tracked-only (staged + unstaged), excludes untracked. Used for **tier/safety decisions** AND for the **aligned-target gating** in `handle_standard_operation` (the skip-when-aligned decision), because no reset mode (`--soft`/`--mixed`/`--keep`/`--hard`) touches untracked files, so untracked files are irrelevant to safety.
+    - `has_untracked_or_pending_changes` (renamed from `has_pending_changes`) -- tracked + untracked (the broadest dirtiness predicate). Used where untracked files matter contextually (e.g. `git-caa`, `git-rb`, `git-w-wip`) -- NOT for the aligned-target gate, which uses the tracked-only predicate above.
+    - **Alignment vs. dirtiness:** alignment itself (whether two refs resolve to the same commit) is tested with `is_aligned` -- NEVER with `count_commits_in_range … == 0` (which also reads `0` when one ref is *behind*). See the "Range counting" subsection under Commit Range Analysis.
   - Other state checks: `has_staged_changes`, `has_unstaged_changes`
 - Cleanliness validation (`check_working_tree_clean`, `check_files_clean`)
 - File state checking (`check_file_in_commit`, `check_file_staged`, `check_file_unstaged`)
@@ -123,14 +124,15 @@ The main `hug-git-kit` file sources all these modules to maintain backward compa
 - Selection helpers (`get_gum_selection_index`, `get_numbered_selection_index`)
 
 #### hug-git-commit
-- Count commits in range (`count_commits_in_range`)
+- Count commits in range (`count_commits_in_range` strict, `count_commits_in_range_or_zero` display-only)
+- Ahead/behind relationship and alignment (`commits_ahead_behind`, `is_aligned`) -- see "Range counting" below
 - List changed files (`list_changed_files_in_range`, `count_changed_files_in_range`)
 - Print commit lists (`print_commit_list_in_range`)
 - Preview helpers (`print_preview_summary`, `print_commit_list_header`)
 
 #### hug-git-upstream
 - Handle upstream operations (`handle_upstream_operation`) -- takes a required `tier` parameter (warn/danger) for the upstream confirmation path. This closes the inverted confirmation gradient: previously every upstream path was gated at warn regardless of the operation's actual danger level.
-- Handle standard operations (`handle_standard_operation`) -- aligned-target gating uses `has_uncommitted_tracked_changes` (tracked-only) for the skip-when-aligned decision.
+- Handle standard operations (`handle_standard_operation`) -- aligned-target gating uses `has_uncommitted_tracked_changes` (tracked-only) for the skip-when-aligned decision. Alignment itself is tested with `is_aligned` (exact SHA equality), NEVER a one-directional `count_commits_in_range … == 0` -- see the "Range counting" subsection. Callers invoke this helper BARE (not via `$(…)`) so its aligned-path `exit 0` terminates the mover.
 - Recovery hint helper (`emit_head_recovery_hint`) -- emits the `hug h restore <SHA> --<op> -y` recovery command to stderr after a successful warn-tier HEAD-mover. Suppressed under `HUG_QUIET=T`. Used by h-back, h-undo, h-rollback, h-rewind (warn), and h-squash.
 - See also: `git-h-restore` -- the recovery primitive that `emit_head_recovery_hint` prints. Uses exact-SHA no-op (never the range-count gate) so it can move HEAD forward to a descendant commit.
 
@@ -410,7 +412,9 @@ fi
 ### Commit Range Analysis
 
 ```bash
-# Count commits between two refs
+# Count commits between two refs -- a ONE-DIRECTIONAL ahead-count: how far HEAD is AHEAD
+# of origin/main. A result of 0 means "HEAD is NOT ahead" (true when aligned OR behind) --
+# it does NOT mean "aligned". STRICT: a bad ref propagates non-zero, never swallowed to 0.
 count=$(count_commits_in_range "origin/main" "HEAD")
 
 # List changed files
@@ -420,19 +424,51 @@ files=$(list_changed_files_in_range "origin/main" "HEAD")
 print_commit_list_in_range "origin/main" "HEAD"
 ```
 
+#### Range counting -- pick the right primitive
+
+- **`count_commits_in_range "start" ["end"]`** -- a ONE-DIRECTIONAL ahead-count: how far
+  `end` is ahead of `start`. A result of `0` means "`end` is NOT ahead of `start`" — which
+  is true BOTH when `end == start` (aligned) AND when `end` is *behind* `start`. **Never
+  treat `0` as "aligned."** STRICT: a failed `rev-list` (invalid ref, unborn HEAD)
+  propagates non-zero — it is NOT swallowed into `0`; callers must handle failure.
+- **`commits_ahead_behind "start" "end"`** -- the full relationship as `"<behind>\t<ahead>"`
+  (git's native `--left-right` order: the FIRST arg's exclusive count comes FIRST). `0\t0`
+  ⟺ aligned. Parse into POSITIONAL fields; never `read ahead behind <<< "…"` (that swaps
+  them, since the name order ≠ output order). Both counts > 0 ⟺ the refs have diverged.
+- **`is_aligned "a" "b"`** -- the ONLY sanctioned alignment test (exit 0 iff `a` and `b`
+  resolve to the same commit). Use this wherever you would otherwise write
+  `count_commits_in_range … == 0` to mean "aligned."
+- **`count_commits_in_range_or_zero`** -- display-only twin: a cosmetic `0` on rev-list
+  failure, for rendered plans / tip text only. NEVER for a branching or alignment decision.
+  This is the single sanctioned `echo 0`-on-failure swallow — it appears nowhere else
+  (the canary `grep -rn '<pipe><pipe> echo 0' git-config/` must stay at exactly one hit;
+  here `<pipe><pipe>` stands for the shell OR operator, written obfuscatedly so this README
+  doesn't itself trip the canary -- the real command greps for that operator immediately
+  followed by `echo 0`).
+
 ### Operation Handlers
 
 ```bash
 # For upstream operations (rewind to upstream, etc.)
 # The tier parameter (warn|danger) controls which prompt function is used.
-target=$(handle_upstream_operation "rewinding" "warn" "rewind" "danger reason")
-# Displays preview, gets tier-appropriate confirmation, returns upstream commit
+# Prints the upstream commit SHA to stdout. Its internal ahead-count is STRICT
+# (count_commits_in_range) and carries `|| return 1`, so capture it with a guard
+# (callers use `|| exit $?`) -- set -e is suspended inside $(…):
+target=$(handle_upstream_operation "rewinding" "warn" "rewind" "danger reason") || exit $?
 
 # For standard operations (back, undo, etc.)
 target=$(resolve_head_target "$1")
+# Called BARE (a plain command, NOT $(…)): when HEAD is already at $target its
+# aligned-guard runs `exit 0`, terminating the whole mover. That guard depends on the
+# bare call -- do NOT capture this helper via $(…) or the exit is swallowed. Alignment
+# is tested with is_aligned (exact SHA), never a one-directional count == 0.
 handle_standard_operation "moving back" "$target"
-prompt_confirm_warn "Proceed? [y/N]: "
-# Displays preview, handles already-at-target case
+prompt_confirm_warn "Proceed? [y/N]: "   # mover confirms AFTER the helper's preview
+
+# Alignment test -- the ONLY sanctioned way to ask "same commit?":
+if is_aligned "$target" HEAD; then
+    info "Already at target; nothing to do."
+fi
 
 # Emit a recovery hint after a successful warn-tier HEAD-mover:
 # Prints "hug h restore <SHA> --<op> -y" to stderr.

--- a/git-config/lib/hug-git-commit
+++ b/git-config/lib/hug-git-commit
@@ -215,8 +215,9 @@ resolve_target_with_temporal() {
 #
 # ONE-DIRECTIONAL ahead-count: a result of 0 means "<end> is NOT ahead of <start>" — which
 # is TRUE in two distinct cases: (1) end == start (aligned), OR (2) end is BEHIND start.
-# Do NOT treat 0 as "aligned." For an alignment test use is_aligned(); for the full
-# ahead/behind relationship use commits_ahead_behind(). See lib/README.md "Range counting".
+# Do NOT treat 0 as "aligned." For an identity test use is_same_commit(); for a signed
+# distance (with direction/magnitude, diverged vs. error distinguished) use commit_offset().
+# See lib/README.md "Range counting".
 #
 # STRICT: a failed rev-list (invalid ref, unborn HEAD) propagates non-zero exit and prints
 # nothing — it is NEVER swallowed into a 0. Callers MUST handle failure (this is the fix for
@@ -245,49 +246,56 @@ count_commits_in_range_or_zero() {
     count_commits_in_range "$@" || echo 0
 }
 
-# Returns the ahead/behind relationship between two commits as "<behind>\t<ahead>"
-# Usage: commits_ahead_behind "start" "end"
-# via the three-dot symmetric difference: git rev-list --left-right --count <start>...<end>
-#   <behind> = commits reachable from <start> but NOT <end>  (end is BEHIND start by this many)
-#   <ahead>  = commits reachable from <end>  but NOT <start> (end is AHEAD of start by this many)
-# Alignment (<start> == <end>) ⟺ "0\t0".
+# True (exit 0) iff <a> and <b> resolve to the SAME existing commit.
+# Usage: is_same_commit "a" "b"
 #
-# NOTE: output order is git's native --left-right order (first arg's exclusive count
-# FIRST) — i.e. "<behind>\t<ahead>", which does NOT match this function's NAME word order
-# ("ahead_behind"). Consumers MUST parse into POSITIONAL field1/field2; NEVER
-# `read ahead behind <<< "…"` — that silently swaps them. When BOTH counts are > 0 the
-# refs have DIVERGED (neither is an ancestor) — a sideways relationship. (Shallow clones:
-# the EQUALITY test via is_aligned is shallow-safe; raw ahead/behind COUNTS are not.)
+# This is the ONLY sanctioned identity/alignment test. NEVER infer alignment from a
+# one-directional count_commits_in_range == 0 — that means "not ahead," which is ALSO
+# true when one ref is BEHIND the other (Defect 1 of elifarley/hug-scm#229).
 #
-# STRICT: a failed rev-list (invalid ref, unborn HEAD) propagates non-zero exit and prints
-# nothing — it is NEVER swallowed into a zero. Callers MUST handle failure.
-commits_ahead_behind() {
-    local start="${1:?commits_ahead_behind: start ref required}"
-    local end="${2:?commits_ahead_behind: end ref required}"
-    git rev-list --left-right --count "$start...$end"
+# PRECONDITION: both <a> and <b> MUST resolve to existing commits. On an unborn repo
+# (no commits) rev-parse --verify fails, so is_same_commit returns NON-ZERO for the
+# trivially-aligned case — a false NEGATIVE, never a false positive. Movers run
+# repo/commit-existence guards first; and even if not, the loud-failure chain holds
+# (the rev-parse failure propagates → callers exit non-zero).
+is_same_commit() {
+    local a b
+    a=$(git rev-parse --verify --quiet "${1:?is_same_commit: first ref required}^{commit}") || return 1
+    b=$(git rev-parse --verify --quiet "${2:?is_same_commit: second ref required}^{commit}") || return 1
+    [ "$a" = "$b" ]
 }
 
-# True (exit 0) iff <a> and <b> resolve to the SAME existing commit.
-# Usage: is_aligned "a" "b"
+# Signed commit distance from <a> to <b> (default HEAD). 0 means IDENTITY (same commit),
+# NOT merely "not ahead" — the false-zero is unrepresentable by construction.
+# Usage: dispatch on $? — exit 2 (diverged) and exit 3 (error) need DISTINCT handling:
+#   offset=$(commit_offset "target" HEAD); rc=$?
+#   case $rc in
+#     0) use "$offset" ;;   # identity (0) or a clean signed distance (N / -N)
+#     2) handle_diverged ;; # incomparable histories — NOT an error, NOT a distance
+#     *) handle_error ;;    # exit 3: an unresolvable ref
+#   esac
+# (The naive `... || handle_error` alone conflates 2 with 3 — diverged is not an error.)
 #
-# This is the ONLY sanctioned alignment test. NEVER infer alignment from a one-directional
-# count_commits_in_range == 0 — that means "not ahead," which is ALSO true when one ref is
-# BEHIND the other (Defect 1 of elifarley/hug-scm#229). For the full ahead/behind
-# relationship use commits_ahead_behind().
+# Contract:
+#   a == b (identity) | stdout=0    exit=0 | at target — undeniable, short-circuited on SHA equality
+#   b ahead of a      | stdout=N    exit=0 | clean forward distance
+#   b behind a        | stdout=-N   exit=0 | forward target (recovery direction)
+#   diverged          | stdout=     exit=2 | incomparable — NOT 0, so never mistaken for aligned
+#   unresolvable ref  | stdout=     exit=3 | error — never a fake 0 (fixes the fallback-swallow, Defect 2)
 #
-# PRECONDITION: both <a> and <b> MUST resolve to existing commits. On an unborn repo (no
-# commits) rev-list exits 128 even for HEAD...HEAD, so is_aligned returns NON-ZERO for the
-# trivially-aligned case — a false NEGATIVE, never a false positive. Movers run repo/commit-
-# existence guards first; and even if not, the loud-failure chain holds (commits_ahead_behind
-# ALSO exits non-zero on unborn → callers propagate).
-#
-# $'0\t0' uses ANSI-C quoting so \t is a real TAB (git's field separator), NOT backslash-t.
-is_aligned() {
-    local a="${1:?is_aligned: first ref required}"
-    local b="${2:?is_aligned: second ref required}"
-    # stderr silenced: a boolean predicate must not spew in `if` contexts; the exit code still
-    # propagates, and a downstream strict count (commits_ahead_behind) surfaces the diagnostic.
-    [ "$(commits_ahead_behind "$a" "$b" 2>/dev/null)" = $'0\t0' ]
+# commit_offset == 0 is a SOUND alignment test — the lossy count == 0 of Defect 1 is gone
+# by construction. is_same_commit is the minimal boolean predicate for callers that need
+# only yes/no; commit_offset is for callers that also need direction/magnitude.
+commit_offset() {
+    local a b
+    a=$(git rev-parse --verify --quiet "${1:?commit_offset: first ref required}^{commit}") || return 3
+    b=$(git rev-parse --verify --quiet "${2:-HEAD}^{commit}") || return 3
+    [ "$a" = "$b" ] && { echo 0; return 0; }                        # identity: the undeniable 0
+    local behind ahead
+    read -r behind ahead < <(git rev-list --left-right --count "$a...$b") || return 3
+    if [ "$behind" -eq 0 ]; then echo "$ahead";   return 0; fi      # b ahead of a
+    if [ "$ahead"  -eq 0 ]; then echo "-$behind"; return 0; fi      # b behind a (forward target)
+    return 2                                                        # diverged: empty + distinct exit
 }
 
 # Prints a list of commits in a given range

--- a/git-config/lib/hug-git-commit
+++ b/git-config/lib/hug-git-commit
@@ -219,6 +219,51 @@ count_commits_in_range() {
     git rev-list --count "$start..$end" 2>/dev/null || echo 0
 }
 
+# Returns the ahead/behind relationship between two commits as "<behind>\t<ahead>"
+# Usage: commits_ahead_behind "start" "end"
+# via the three-dot symmetric difference: git rev-list --left-right --count <start>...<end>
+#   <behind> = commits reachable from <start> but NOT <end>  (end is BEHIND start by this many)
+#   <ahead>  = commits reachable from <end>  but NOT <start> (end is AHEAD of start by this many)
+# Alignment (<start> == <end>) ⟺ "0\t0".
+#
+# NOTE: output order is git's native --left-right order (first arg's exclusive count
+# FIRST) — i.e. "<behind>\t<ahead>", which does NOT match this function's NAME word order
+# ("ahead_behind"). Consumers MUST parse into POSITIONAL field1/field2; NEVER
+# `read ahead behind <<< "…"` — that silently swaps them. When BOTH counts are > 0 the
+# refs have DIVERGED (neither is an ancestor) — a sideways relationship. (Shallow clones:
+# the EQUALITY test via is_aligned is shallow-safe; raw ahead/behind COUNTS are not.)
+#
+# STRICT: a failed rev-list (invalid ref, unborn HEAD) propagates non-zero exit and prints
+# nothing — it is NEVER swallowed into a zero. Callers MUST handle failure.
+commits_ahead_behind() {
+    local start="${1:?commits_ahead_behind: start ref required}"
+    local end="${2:?commits_ahead_behind: end ref required}"
+    git rev-list --left-right --count "$start...$end"
+}
+
+# True (exit 0) iff <a> and <b> resolve to the SAME existing commit.
+# Usage: is_aligned "a" "b"
+#
+# This is the ONLY sanctioned alignment test. NEVER infer alignment from a one-directional
+# count_commits_in_range == 0 — that means "not ahead," which is ALSO true when one ref is
+# BEHIND the other (Defect 1 of elifarley/hug-scm#229). For the full ahead/behind
+# relationship use commits_ahead_behind().
+#
+# PRECONDITION: both <a> and <b> MUST resolve to existing commits. On an unborn repo (no
+# commits) rev-list exits 128 even for HEAD...HEAD, so is_aligned returns NON-ZERO for the
+# trivially-aligned case — a false NEGATIVE, never a false positive. Movers run repo/commit-
+# existence guards first; and even if not, the loud-failure chain holds (commits_ahead_behind
+# ALSO exits non-zero on unborn → callers propagate).
+#
+# $'0\t0' uses ANSI-C quoting so \t is a real TAB (git's field separator), NOT backslash-t.
+is_aligned() {
+    local a="${1:?is_aligned: first ref required}"
+    local b="${2:?is_aligned: second ref required}"
+    # stderr silenced: a boolean predicate must not spew in `if` contexts; the exit code still
+    # propagates, and a downstream strict count (commits_ahead_behind) surfaces the diagnostic.
+    [ "$(commits_ahead_behind "$a" "$b" 2>/dev/null)" = $'0\t0' ]
+}
+
 # Prints a list of commits in a given range
 # Usage: print_commit_list_in_range "start" ["end"]
 # Parameters:

--- a/git-config/lib/hug-git-commit
+++ b/git-config/lib/hug-git-commit
@@ -205,18 +205,44 @@ resolve_target_with_temporal() {
 # Commit Range Analysis Functions
 ################################################################################
 
-# Counts commits in a range
+# Counts how far <end> is AHEAD of <start> (commits reachable from <end> but not <start>).
 # Usage: count=$(count_commits_in_range "start" ["end"])
 # Parameters:
-#   $1 - Start commit (exclusive)
+#   $1 - Start commit (exclusive) — REQUIRED
 #   $2 - (Optional) End commit (inclusive), defaults to HEAD
 # Output:
-#   Number of commits in range to stdout
+#   Number of commits in range to stdout.
+#
+# ONE-DIRECTIONAL ahead-count: a result of 0 means "<end> is NOT ahead of <start>" — which
+# is TRUE in two distinct cases: (1) end == start (aligned), OR (2) end is BEHIND start.
+# Do NOT treat 0 as "aligned." For an alignment test use is_aligned(); for the full
+# ahead/behind relationship use commits_ahead_behind(). See lib/README.md "Range counting".
+#
+# STRICT: a failed rev-list (invalid ref, unborn HEAD) propagates non-zero exit and prints
+# nothing — it is NEVER swallowed into a 0. Callers MUST handle failure (this is the fix for
+# Defect 2 of elifarley/hug-scm#229; the old "echo 0 on failure" swallow let errors masquerade
+# as data).
+#
+# NOTE: the ${1:?} guard is a hard shell EXIT (not a catchable return) if this function is
+# called directly with a missing start arg; it is catchable via `|| exit 1`/`|| return 1`
+# only because callers invoke it inside a $(…) command substitution. Always pass a start ref.
 count_commits_in_range() {
-    local start="$1"
+    local start="${1:?count_commits_in_range: start ref required}"
     local end="${2:-HEAD}"
 
-    git rev-list --count "$start..$end" 2>/dev/null || echo 0
+    git rev-list --count "$start..$end"
+}
+
+# STRICT-display twin of count_commits_in_range.
+# Usage: count=$(count_commits_in_range_or_zero "start" ["end"])
+# ONLY for display/tip text where a 0 on rev-list failure is cosmetically acceptable
+# (e.g. a rendered plan or a "… in N commits since …" tip). NEVER use this for a branching
+# or alignment decision — there, count_commits_in_range's strict propagation MUST surface
+# the failure. Grep invariant: this "echo 0" swallow appears NOWHERE outside this one body line.
+# (These comments deliberately avoid the literal pipe-form of the pattern so the canary
+# `grep -rn '<pipe><pipe> echo 0' git-config/` stays at exactly ONE hit — don't re-add it.)
+count_commits_in_range_or_zero() {
+    count_commits_in_range "$@" || echo 0
 }
 
 # Returns the ahead/behind relationship between two commits as "<behind>\t<ahead>"

--- a/git-config/lib/hug-git-rebase
+++ b/git-config/lib/hug-git-rebase
@@ -235,7 +235,7 @@ rb_build_plan() {
   local no_backup="${3:-false}"
 
   local num_commits
-  num_commits=$(count_commits_in_range "$target_branch" HEAD)
+  num_commits=$(count_commits_in_range_or_zero "$target_branch" HEAD)
 
   local will_backup="true"
   local tier="warn"

--- a/git-config/lib/hug-git-upstream
+++ b/git-config/lib/hug-git-upstream
@@ -46,7 +46,7 @@ handle_upstream_operation() {
     fi
 
     local local_commits
-    local_commits=$(count_commits_in_range "$target" HEAD)
+    local_commits=$(count_commits_in_range "$target" HEAD) || return 1
 
     if [ "$local_commits" -eq 0 ]; then
         info "Already synced to upstream ($(git rev-parse --short "$target"))."

--- a/git-config/lib/hug-git-upstream
+++ b/git-config/lib/hug-git-upstream
@@ -98,7 +98,7 @@ handle_upstream_operation() {
 # Note:
 #   This helper is read-only: never mutates commits, index, or working tree
 #   Displays commit list and file change statistics for the operation
-#   Alignment is guarded by is_aligned (EXACT SHA equality) — NOT a one-directional
+#   Alignment is guarded by is_same_commit (EXACT SHA equality) — NOT a one-directional
 #   count == 0, which is also true when HEAD is BEHIND the target (see Defect-1 fix below).
 #   Called BARE by the movers (plain command, not $(…)), so the aligned-path exit 0
 #   terminates the whole mover. Preserve this contract; do not capture via $(…).
@@ -107,12 +107,12 @@ handle_standard_operation() {
     local target="$2"
     local skip_when_aligned="${3:-true}"
 
-    # Defect-1 fix (#229): alignment is an EXACT SHA relationship (is_aligned), never a
+    # Defect-1 fix (#229): alignment is an EXACT SHA relationship (is_same_commit), never a
     # one-directional count == 0 (which is ALSO true when HEAD is BEHIND the target). A
     # forward (descendant) target used to no-op here; now only a truly-aligned target does.
     # Called BARE by the movers (plain command, not $(…)), so this exit 0 terminates the
     # whole mover — preserved on purpose; do not capture this helper via $(…).
-    if is_aligned "$target" HEAD; then
+    if is_same_commit "$target" HEAD; then
         if [[ "$skip_when_aligned" == true ]] || ! has_uncommitted_tracked_changes; then
             info "Already at target $(git rev-parse --short "$target"). No action taken."
             exit 0

--- a/git-config/lib/hug-git-upstream
+++ b/git-config/lib/hug-git-upstream
@@ -98,25 +98,41 @@ handle_upstream_operation() {
 # Note:
 #   This helper is read-only: never mutates commits, index, or working tree
 #   Displays commit list and file change statistics for the operation
+#   Alignment is guarded by is_aligned (EXACT SHA equality) — NOT a one-directional
+#   count == 0, which is also true when HEAD is BEHIND the target (see Defect-1 fix below).
+#   Called BARE by the movers (plain command, not $(…)), so the aligned-path exit 0
+#   terminates the whole mover. Preserve this contract; do not capture via $(…).
 handle_standard_operation() {
     local action_name="$1"
     local target="$2"
     local skip_when_aligned="${3:-true}"
 
-    local commits_to_affected
-    commits_to_affected=$(count_commits_in_range "$target" HEAD)
-
-    if [ "$commits_to_affected" -eq 0 ]; then
+    # Defect-1 fix (#229): alignment is an EXACT SHA relationship (is_aligned), never a
+    # one-directional count == 0 (which is ALSO true when HEAD is BEHIND the target). A
+    # forward (descendant) target used to no-op here; now only a truly-aligned target does.
+    # Called BARE by the movers (plain command, not $(…)), so this exit 0 terminates the
+    # whole mover — preserved on purpose; do not capture this helper via $(…).
+    if is_aligned "$target" HEAD; then
         if [[ "$skip_when_aligned" == true ]] || ! has_uncommitted_tracked_changes; then
             info "Already at target $(git rev-parse --short "$target"). No action taken."
             exit 0
         fi
-
         if [[ ${HUG_QUIET:-} != T ]]; then
             info "No commits to $action_name; local tracked changes will be reset."
         fi
         return 0
     fi
+
+    # NOT aligned. Count ahead-commits STRICTLY for the preview (the old "echo 0" swallow
+    # lived inside count_commits_in_range's body — removed in #229 Defect 2; this site now
+    # propagates strictly).
+    # `|| return 1` is belt-and-suspenders here: this function is called BARE (set -e active),
+    # unlike handle_upstream_operation which is called via `|| exit $?` (set -e suppressed)
+    # and therefore REQUIRES its own guard. For a forward target this count is 0 (HEAD is
+    # behind) and the preview reads "changes in 0 commit:" above the diff stat — cosmetically
+    # rough; Phase 2 makes it direction-aware. The operation PROCEEDS either way.
+    local commits_to_affected
+    commits_to_affected=$(count_commits_in_range "$target" HEAD) || return 1
 
     if [[ ${HUG_QUIET:-} != T ]]; then
         local range_for_diff

--- a/tests/lib/test_hug-git-commit.bats
+++ b/tests/lib/test_hug-git-commit.bats
@@ -147,6 +147,53 @@ teardown() {
 }
 
 ################################################################################
+# count_commits_in_range STRICTNESS TESTS (Defect 2)
+################################################################################
+
+@test "count_commits_in_range: invalid start -> non-zero, empty stdout (strict, no swallow)" {
+  bats_require_minimum_version 1.5.0
+  run --separate-stderr count_commits_in_range NO_SUCH_REF HEAD
+  assert_failure
+  assert_output ""        # stdout empty (git's fatal: is on stderr, deliberately uncaptured)
+}
+
+@test "count_commits_in_range: missing start arg -> fails fast via \${1:?}" {
+  run count_commits_in_range
+  assert_failure
+}
+
+################################################################################
+# count_commits_in_range_or_zero TESTS (named display wrapper)
+################################################################################
+
+@test "count_commits_in_range_or_zero: valid range -> same as strict count" {
+  run count_commits_in_range_or_zero HEAD~2 HEAD
+  assert_success
+  assert_output "2"
+}
+
+@test "count_commits_in_range_or_zero: single arg defaults end to HEAD" {
+  # The wrapper forwards "$@" verbatim, so the strict function's ${2:-HEAD} default must
+  # still apply through the passthrough: a lone start ref counts commits from <start> to
+  # HEAD. setup() makes 3 commits, so HEAD~1 -> 1.
+  run count_commits_in_range_or_zero HEAD~1
+  assert_success
+  assert_output "1"
+}
+
+@test "count_commits_in_range_or_zero: invalid start -> echoes 0, exit 0 (cosmetic)" {
+  # The wrapper swallows the FAILURE (non-zero exit -> cosmetic 0 on stdout), but git's
+  # `fatal: ambiguous argument` diagnostic still goes to STDERR. bats' default `run` MERGES
+  # stderr into $output, which would make `assert_output "0"` see that 3-line diagnostic + "0".
+  # The contract under test is stdout == "0" + exit 0, so split stderr out (same house pattern
+  # as the strict invalid-ref tests above; --separate-stderr needs bats >= 1.5).
+  bats_require_minimum_version 1.5.0
+  run --separate-stderr count_commits_in_range_or_zero NO_SUCH_REF HEAD
+  assert_success
+  assert_output "0"
+}
+
+################################################################################
 # list_changed_files_in_range TESTS
 ################################################################################
 

--- a/tests/lib/test_hug-git-commit.bats
+++ b/tests/lib/test_hug-git-commit.bats
@@ -52,6 +52,101 @@ teardown() {
 }
 
 ################################################################################
+# commits_ahead_behind TESTS
+################################################################################
+
+@test "commits_ahead_behind: ancestor pair -> 0<TAB>N (end ahead of start)" {
+  run commits_ahead_behind HEAD~2 HEAD
+  assert_success
+  assert_output "$(printf '0\t2')"
+}
+
+@test "commits_ahead_behind: descendant pair -> N<TAB>0 (end behind start)" {
+  run commits_ahead_behind HEAD HEAD~2
+  assert_success
+  assert_output "$(printf '2\t0')"
+}
+
+@test "commits_ahead_behind: aligned -> 0<TAB>0" {
+  run commits_ahead_behind HEAD HEAD
+  assert_success
+  assert_output "$(printf '0\t0')"
+}
+
+@test "commits_ahead_behind: diverged pair -> both counts > 0" {
+  git switch -q -c side HEAD~1
+  echo x > side.txt; git add side.txt; git commit -qm "side commit"
+  git switch -q -
+  run commits_ahead_behind side HEAD
+  assert_success
+  assert_output "$(printf '1\t1')"
+}
+
+@test "commits_ahead_behind: invalid ref -> non-zero, empty stdout (strict)" {
+  # Acceptance criterion is "empty STDOUT": git's `fatal: ambiguous argument`
+  # diagnostic is emitted on STDERR and is deliberately NOT swallowed (loud
+  # failure — callers must see it and handle the non-zero exit). bats' default
+  # `run` MERGES stderr into $output, which would make `assert_output ""` fail
+  # on that diagnostic; --separate-stderr keeps $output = stdout ONLY, so we
+  # assert the real contract (stdout empty + non-zero exit) without touching the
+  # wanted stderr noise.
+  bats_require_minimum_version 1.5.0  # `run --separate-stderr` needs >= 1.5 (silences BW02)
+  run --separate-stderr commits_ahead_behind NO_SUCH_REF HEAD
+  assert_failure
+  assert_output ""
+  [ -n "$stderr" ]   # git's 'fatal: ambiguous argument' must survive (loud failure)
+}
+
+@test "commits_ahead_behind: missing args -> fails fast via \${1:?}" {
+  run commits_ahead_behind
+  assert_failure
+}
+
+################################################################################
+# is_aligned TESTS
+################################################################################
+
+@test "is_aligned: same SHA -> exit 0" {
+  run is_aligned HEAD HEAD
+  assert_success
+}
+
+@test "is_aligned: ancestor (not equal) -> non-zero" {
+  run is_aligned HEAD~1 HEAD
+  assert_failure
+}
+
+@test "is_aligned: descendant (not equal) -> non-zero" {
+  local descendant; descendant=$(git rev-parse HEAD)
+  git reset -q --hard HEAD~1
+  run is_aligned "$descendant" HEAD
+  assert_failure
+}
+
+@test "is_aligned: invalid ref -> non-zero (never a false positive)" {
+  run is_aligned NO_SUCH_REF HEAD
+  assert_failure
+}
+
+@test "is_aligned: unborn repo (no commits) -> non-zero (false NEGATIVE, documented)" {
+  # create_test_repo auto-commits an "Initial commit", so it is NOT unborn.
+  # Build a genuinely commit-less repo: mktemp -d yields the path (git init -q
+  # prints nothing to stdout, so it must NOT be captured for the path).
+  local empty_repo; empty_repo=$(mktemp -d)
+  git init -q "$empty_repo"
+  cd "$empty_repo"
+  run is_aligned HEAD HEAD
+  assert_failure
+  cd "$TEST_REPO"
+  rm -rf "$empty_repo"
+}
+
+@test "is_aligned: missing second arg -> fails fast via \${2:?}" {
+  run is_aligned HEAD
+  assert_failure
+}
+
+################################################################################
 # list_changed_files_in_range TESTS
 ################################################################################
 

--- a/tests/lib/test_hug-git-commit.bats
+++ b/tests/lib/test_hug-git-commit.bats
@@ -52,97 +52,96 @@ teardown() {
 }
 
 ################################################################################
-# commits_ahead_behind TESTS
+# commit_offset TESTS
 ################################################################################
 
-@test "commits_ahead_behind: ancestor pair -> 0<TAB>N (end ahead of start)" {
-  run commits_ahead_behind HEAD~2 HEAD
+@test "commit_offset: ancestor pair -> stdout=N (b ahead of a)" {
+  run commit_offset HEAD~2 HEAD
   assert_success
-  assert_output "$(printf '0\t2')"
+  assert_output "2"
 }
 
-@test "commits_ahead_behind: descendant pair -> N<TAB>0 (end behind start)" {
-  run commits_ahead_behind HEAD HEAD~2
+@test "commit_offset: descendant pair -> stdout=-N (b behind a)" {
+  run commit_offset HEAD HEAD~2
   assert_success
-  assert_output "$(printf '2\t0')"
+  assert_output "-2"
 }
 
-@test "commits_ahead_behind: aligned -> 0<TAB>0" {
-  run commits_ahead_behind HEAD HEAD
+@test "commit_offset: identity -> stdout=0 exit=0" {
+  run commit_offset HEAD HEAD
   assert_success
-  assert_output "$(printf '0\t0')"
+  assert_output "0"
 }
 
-@test "commits_ahead_behind: diverged pair -> both counts > 0" {
+@test "commit_offset: diverged -> empty stdout, exit 2" {
   git switch -q -c side HEAD~1
   echo x > side.txt; git add side.txt; git commit -qm "side commit"
   git switch -q -
-  run commits_ahead_behind side HEAD
-  assert_success
-  assert_output "$(printf '1\t1')"
-}
-
-@test "commits_ahead_behind: invalid ref -> non-zero, empty stdout (strict)" {
-  # Acceptance criterion is "empty STDOUT": git's `fatal: ambiguous argument`
-  # diagnostic is emitted on STDERR and is deliberately NOT swallowed (loud
-  # failure — callers must see it and handle the non-zero exit). bats' default
-  # `run` MERGES stderr into $output, which would make `assert_output ""` fail
-  # on that diagnostic; --separate-stderr keeps $output = stdout ONLY, so we
-  # assert the real contract (stdout empty + non-zero exit) without touching the
-  # wanted stderr noise.
-  bats_require_minimum_version 1.5.0  # `run --separate-stderr` needs >= 1.5 (silences BW02)
-  run --separate-stderr commits_ahead_behind NO_SUCH_REF HEAD
-  assert_failure
+  # bats' default `run` MERGES stderr into $output. commit_offset emits nothing
+  # on stdout for the diverged case (the contract: empty + distinct exit code),
+  # but git's rev-list may write to stderr; --separate-stderr keeps $output =
+  # stdout ONLY so we assert the real contract.
+  bats_require_minimum_version 1.5.0
+  run --separate-stderr commit_offset side HEAD
+  [ "$status" -eq 2 ]
   assert_output ""
-  [ -n "$stderr" ]   # git's 'fatal: ambiguous argument' must survive (loud failure)
 }
 
-@test "commits_ahead_behind: missing args -> fails fast via \${1:?}" {
-  run commits_ahead_behind
+@test "commit_offset: invalid ref -> empty stdout, exit 3 (never a fake 0)" {
+  # STRICT: an unresolvable ref is exit 3 with EMPTY stdout — the lossy
+  # `|| echo 0` swallow of Defect 2 is gone by construction.
+  bats_require_minimum_version 1.5.0
+  run --separate-stderr commit_offset NO_SUCH_REF HEAD
+  [ "$status" -eq 3 ]
+  assert_output ""
+}
+
+@test "commit_offset: missing args -> fails fast via \${1:?}" {
+  run commit_offset
   assert_failure
 }
 
 ################################################################################
-# is_aligned TESTS
+# is_same_commit TESTS
 ################################################################################
 
-@test "is_aligned: same SHA -> exit 0" {
-  run is_aligned HEAD HEAD
+@test "is_same_commit: same SHA -> exit 0" {
+  run is_same_commit HEAD HEAD
   assert_success
 }
 
-@test "is_aligned: ancestor (not equal) -> non-zero" {
-  run is_aligned HEAD~1 HEAD
+@test "is_same_commit: ancestor (not equal) -> non-zero" {
+  run is_same_commit HEAD~1 HEAD
   assert_failure
 }
 
-@test "is_aligned: descendant (not equal) -> non-zero" {
+@test "is_same_commit: descendant (not equal) -> non-zero" {
   local descendant; descendant=$(git rev-parse HEAD)
   git reset -q --hard HEAD~1
-  run is_aligned "$descendant" HEAD
+  run is_same_commit "$descendant" HEAD
   assert_failure
 }
 
-@test "is_aligned: invalid ref -> non-zero (never a false positive)" {
-  run is_aligned NO_SUCH_REF HEAD
+@test "is_same_commit: invalid ref -> non-zero (never a false positive)" {
+  run is_same_commit NO_SUCH_REF HEAD
   assert_failure
 }
 
-@test "is_aligned: unborn repo (no commits) -> non-zero (false NEGATIVE, documented)" {
+@test "is_same_commit: unborn repo (no commits) -> non-zero (false NEGATIVE, documented)" {
   # create_test_repo auto-commits an "Initial commit", so it is NOT unborn.
   # Build a genuinely commit-less repo: mktemp -d yields the path (git init -q
   # prints nothing to stdout, so it must NOT be captured for the path).
   local empty_repo; empty_repo=$(mktemp -d)
   git init -q "$empty_repo"
   cd "$empty_repo"
-  run is_aligned HEAD HEAD
+  run is_same_commit HEAD HEAD
   assert_failure
   cd "$TEST_REPO"
   rm -rf "$empty_repo"
 }
 
-@test "is_aligned: missing second arg -> fails fast via \${2:?}" {
-  run is_aligned HEAD
+@test "is_same_commit: missing second arg -> fails fast via \${2:?}" {
+  run is_same_commit HEAD
   assert_failure
 }
 

--- a/tests/lib/test_hug-upstream.bats
+++ b/tests/lib/test_hug-upstream.bats
@@ -112,3 +112,41 @@ teardown() {
   assert_success                              # returns past the guard (does not exit 0 early)
   refute_output --partial "Already at target" # the guard was NOT taken
 }
+
+################################################################################
+# Defect-2 strict propagation: a bad ref / missing upstream must return non-zero
+################################################################################
+# WHY these exist: pre-#229, count_commits_in_range swallowed a failed rev-list into
+# `echo 0`, so an invalid ref or a missing upstream surfaced as a *plausible-looking*
+# zero count ("0 commits" / "Already synced") and the helper returned SUCCESS. The fix
+# removed the swallow; every strict call site now propagates non-zero. These two tests
+# pin that guarantee at the LIBRARY level (the command-level pins live in test_head.bats).
+#
+# They pin the USER-VISIBLE guarantee (non-zero return, never a silent no-op), NOT the exact strict
+# site. That mechanism is isolated one layer down by the primitive canary at
+# tests/lib/test_hug-git-commit.bats (count_commits_in_range strictness) — mutation-testing shows
+# re-adding the swallow merely RELOCATES the failure downstream (the helper-tail `git diff --stat`
+# still fails on the bad range), so these stay green by design. Read them as "the helper fails
+# loudly," not "this specific guard propagates."
+
+@test "handle_standard_operation: invalid target -> non-zero (strict, not a silent no-op)" {
+  # A non-resolving target is NOT aligned: is_aligned is a false-NEGATIVE-only predicate
+  # (commits_ahead_behind fails -> non-zero -> the `[ … = 0\t0 ]` test is false), so the helper
+  # proceeds past the aligned-guard and fails loudly on the bad ref. The FIRST strict site it hits is
+  # count_commits_in_range (`git rev-list --count NO_SUCH_REF..HEAD`), but that is NOT the only possible
+  # failure point — re-adding the swallow there just relocates the failure to the helper-tail
+  # `git diff --stat NO_SUCH_REF..HEAD` (see the section header). The pinned guarantee is the non-zero
+  # return + no misleading "Already at target"; pre-fix the swallow rendered a '0 commits' no-op (return 0).
+  run handle_standard_operation "move back" "NO_SUCH_REF_XYZ"
+  assert_failure
+  refute_output --partial "Already at target" # the misleading pre-fix no-op message must NOT appear
+}
+
+@test "handle_upstream_operation: no upstream -> non-zero (strict guarantee)" {
+  # create_test_repo_with_history configures NO upstream, so get_upstream_commit exits non-zero
+  # inside the $(…) substitution; `target=$(get_upstream_commit) || return 1` propagates it
+  # (hug-git-upstream:41). Pre-fix the missing upstream could be masked downstream; now the helper
+  # returns non-zero instead of echoing an empty target that word-splits into a bogus default.
+  run handle_upstream_operation "moving" warn "move" "reason"
+  assert_failure
+}

--- a/tests/lib/test_hug-upstream.bats
+++ b/tests/lib/test_hug-upstream.bats
@@ -96,3 +96,19 @@ teardown() {
   assert_success
   [ -z "$output" ]
 }
+
+################################################################################
+# handle_standard_operation: Defect-1 regression (forward target must NOT no-op)
+################################################################################
+
+@test "handle_standard_operation: forward (descendant) target does NOT no-op (Defect 1)" {
+  # HEAD at an ancestor; target is a descendant. Pre-fix this printed 'Already at target'.
+  # The old guard was `count target..HEAD == 0`, which is ALSO true when HEAD is BEHIND the
+  # target (a forward target), so the mover silently no-op'ed. is_aligned (exact SHA equality)
+  # is the correct guard: a forward target is NOT aligned and must proceed.
+  local descendant; descendant=$(git rev-parse HEAD)
+  git update-ref HEAD HEAD~1                  # move HEAD back one (plumbing; avoids git reset/checkout)
+  run handle_standard_operation "move back" "$descendant"
+  assert_success                              # returns past the guard (does not exit 0 early)
+  refute_output --partial "Already at target" # the guard was NOT taken
+}

--- a/tests/lib/test_hug-upstream.bats
+++ b/tests/lib/test_hug-upstream.bats
@@ -104,7 +104,7 @@ teardown() {
 @test "handle_standard_operation: forward (descendant) target does NOT no-op (Defect 1)" {
   # HEAD at an ancestor; target is a descendant. Pre-fix this printed 'Already at target'.
   # The old guard was `count target..HEAD == 0`, which is ALSO true when HEAD is BEHIND the
-  # target (a forward target), so the mover silently no-op'ed. is_aligned (exact SHA equality)
+  # target (a forward target), so the mover silently no-op'ed. is_same_commit (exact SHA equality)
   # is the correct guard: a forward target is NOT aligned and must proceed.
   local descendant; descendant=$(git rev-parse HEAD)
   git update-ref HEAD HEAD~1                  # move HEAD back one (plumbing; avoids git reset/checkout)
@@ -130,8 +130,8 @@ teardown() {
 # loudly," not "this specific guard propagates."
 
 @test "handle_standard_operation: invalid target -> non-zero (strict, not a silent no-op)" {
-  # A non-resolving target is NOT aligned: is_aligned is a false-NEGATIVE-only predicate
-  # (commits_ahead_behind fails -> non-zero -> the `[ … = 0\t0 ]` test is false), so the helper
+  # A non-resolving target is NOT aligned: is_same_commit is a false-NEGATIVE-only predicate
+  # (rev-parse --verify fails -> non-zero -> the SHA-equality test is false), so the helper
   # proceeds past the aligned-guard and fails loudly on the bad ref. The FIRST strict site it hits is
   # count_commits_in_range (`git rev-list --count NO_SUCH_REF..HEAD`), but that is NOT the only possible
   # failure point — re-adding the swallow there just relocates the failure to the helper-tail

--- a/tests/unit/test_commit.bats
+++ b/tests/unit/test_commit.bats
@@ -970,6 +970,58 @@ HOOK
   rm -rf "$repo"
 }
 
+# cmv 0-commit guard: the `count == 0` no-op is CORRECT for cmv (its target must be an
+# ancestor — "commit to move above" / "reset branch back" — so a descendant has nothing
+# above it). These tests pin BOTH truthful sub-case messages AND the no-regression invariant
+# that the current branch never moves: a forward (descendant) target must NOT fall through
+# to the tail's `git reset --hard`, which would hard-reset the branch FORWARD + switch branch
+# on a 'NOT RESTORABLE' command. The message must branch on is_aligned because a commit is its
+# own ancestor (equality-as-ancestry): "already at" when aligned, "is a descendant" otherwise.
+@test "hug cmv: aligned target (HEAD) -> 'already at' message, branch unmoved" {
+  local repo
+  repo=$(create_test_repo_with_history)
+  pushd "$repo" >/dev/null
+
+  git checkout -q -b feature
+  local before
+  before=$(git rev-parse HEAD)
+
+  run env HUG_FORCE=true hug cmv HEAD main
+  assert_success
+  assert_output --partial "already at"
+  refute_output --partial "is a descendant"
+  # Current branch did NOT move (guard exits before any reset)
+  [ "$(git rev-parse HEAD)" = "$before" ]
+
+  popd >/dev/null
+  rm -rf "$repo"
+}
+
+@test "hug cmv: descendant target -> 'is a descendant of HEAD' message, branch unmoved" {
+  local repo
+  repo=$(create_test_repo_with_history)
+  pushd "$repo" >/dev/null
+
+  git checkout -q -b feature
+  # Current HEAD becomes the FORWARD (descendant) target; then move feature back one commit so
+  # the target is a descendant of the new HEAD — an incoherent cmv request that must no-op.
+  local descendant
+  descendant=$(git rev-parse HEAD)
+  git reset -q --hard HEAD~1
+  local before
+  before=$(git rev-parse HEAD)
+
+  run env HUG_FORCE=true hug cmv "$descendant" main
+  assert_success
+  assert_output --partial "is a descendant of HEAD"
+  refute_output --partial "already at"
+  # Current branch did NOT move forward (no forward-hard-reset regression)
+  [ "$(git rev-parse HEAD)" = "$before" ]
+
+  popd >/dev/null
+  rm -rf "$repo"
+}
+
 # Additional cmv edge cases...
 
 # -----------------------------------------------------------------------------

--- a/tests/unit/test_commit.bats
+++ b/tests/unit/test_commit.bats
@@ -975,7 +975,7 @@ HOOK
 # above it). These tests pin BOTH truthful sub-case messages AND the no-regression invariant
 # that the current branch never moves: a forward (descendant) target must NOT fall through
 # to the tail's `git reset --hard`, which would hard-reset the branch FORWARD + switch branch
-# on a 'NOT RESTORABLE' command. The message must branch on is_aligned because a commit is its
+# on a 'NOT RESTORABLE' command. The message must branch on is_same_commit because a commit is its
 # own ancestor (equality-as-ancestry): "already at" when aligned, "is a descendant" otherwise.
 @test "hug cmv: aligned target (HEAD) -> 'already at' message, branch unmoved" {
   local repo

--- a/tests/unit/test_h_restore.bats
+++ b/tests/unit/test_h_restore.bats
@@ -37,9 +37,9 @@ teardown() {
   assert_output --partial "Already at"
 }
 
-@test "restore: aligned target (HEAD) -> 'Nothing to restore' no-op (via is_aligned)" {
-  # The aligned no-op must be preserved across the SHA-compare -> is_aligned migration:
-  # is_aligned "$target" HEAD is true when both resolve to the same commit, exactly the
+@test "restore: aligned target (HEAD) -> 'Nothing to restore' no-op (via is_same_commit)" {
+  # The aligned no-op must be preserved across the SHA-compare -> is_same_commit migration:
+  # is_same_commit "$target" HEAD is true when both resolve to the same commit, exactly the
   # "already there" case. An op flag (--back) is required even for the no-op path.
   run env HUG_FORCE=true hug h restore "$(git rev-parse HEAD)" --back
   assert_success
@@ -48,7 +48,7 @@ teardown() {
 
 @test "restore: invalid SHA -> loud failure (not silent)" {
   # A non-existent ref must NOT become a silent no-op. resolve_target_with_temporal does
-  # not validate — it echoes the unresolved ref (exit 0) — so the bad ref reaches is_aligned
+  # not validate — it echoes the unresolved ref (exit 0) — so the bad ref reaches is_same_commit
   # (which declines the no-op branch) and then fails loudly at the downstream
   # `git rev-parse --short` / `git reset` (exit 128).
   run env HUG_FORCE=true hug h restore NO_SUCH_REF_XYZ --back

--- a/tests/unit/test_h_restore.bats
+++ b/tests/unit/test_h_restore.bats
@@ -37,6 +37,24 @@ teardown() {
   assert_output --partial "Already at"
 }
 
+@test "restore: aligned target (HEAD) -> 'Nothing to restore' no-op (via is_aligned)" {
+  # The aligned no-op must be preserved across the SHA-compare -> is_aligned migration:
+  # is_aligned "$target" HEAD is true when both resolve to the same commit, exactly the
+  # "already there" case. An op flag (--back) is required even for the no-op path.
+  run env HUG_FORCE=true hug h restore "$(git rev-parse HEAD)" --back
+  assert_success
+  assert_output --partial "Nothing to restore"
+}
+
+@test "restore: invalid SHA -> loud failure (not silent)" {
+  # A non-existent ref must NOT become a silent no-op. resolve_target_with_temporal does
+  # not validate — it echoes the unresolved ref (exit 0) — so the bad ref reaches is_aligned
+  # (which declines the no-op branch) and then fails loudly at the downstream
+  # `git rev-parse --short` / `git reset` (exit 128).
+  run env HUG_FORCE=true hug h restore NO_SUCH_REF_XYZ --back
+  assert_failure
+}
+
 @test "restore: forward (descendant) target MOVES HEAD (no short-circuit no-op)" {
   hug h back 2 --force                              # HEAD now 2 behind
   ahead=$(git rev-parse "HEAD@{1}")                 # a descendant of current HEAD

--- a/tests/unit/test_head.bats
+++ b/tests/unit/test_head.bats
@@ -1531,6 +1531,34 @@ EOF
   [ "$(git rev-list --count HEAD)" = "$commit_count_before" ]
 }
 
+@test "h-squash <SHA-of-HEAD>: live '== 0' branch -> 'No commits to squash', NO commit created (regression pin)" {
+  # Regression pin for git-h-squash's top-level '== 0' guard (fed by the
+  # non-upstream count site). This branch is LIVE, not dead code: passing the
+  # SHA of HEAD as the target sails through ensure_ancestor_of_head because
+  # `git merge-base --is-ancestor X X` treats EQUALITY as ancestry (exit 0), and
+  # with target == HEAD there are 0 commits in target..HEAD, so the guard fires
+  # ("No commits to squash", exit 0, no commit created). Pins the branch against
+  # a future "dead code" cleanup that mistakes it for unreachable — see the
+  # assertion-area comment below for what actually detects the regression.
+  local head_sha; head_sha=$(git rev-parse HEAD)
+  local before; before=$(git rev-parse HEAD)
+  local commit_count_before; commit_count_before=$(git rev-list --count HEAD)
+
+  run hug h squash "$head_sha" --force
+  assert_success
+  assert_output --partial "No commits to squash"
+
+  # The PRIMARY detector is the message assertion above: with the guard removed,
+  # this clean-repo fixture (create_test_repo_with_history commits everything)
+  # takes the buggy path ("Skipping commit (empty squash?)") and moves HEAD onto
+  # itself — fabricating NO commit — so 'assert_output --partial "No commits to
+  # squash"' is what catches the regression. The HEAD / commit-count checks below
+  # are defense-in-depth against a variant that WOULD fabricate a commit. (An
+  # exit-code-only check is useless: the buggy path also exits 0.)
+  [ "$(git rev-parse HEAD)" = "$before" ]
+  [ "$(git rev-list --count HEAD)" = "$commit_count_before" ]
+}
+
 @test "h-squash --help documents RESTORE" {
   run hug h squash --help
   assert_output --partial "RESTORE"

--- a/tests/unit/test_head.bats
+++ b/tests/unit/test_head.bats
@@ -2175,3 +2175,90 @@ EOF
   assert_output --partial "RESTORE"
   assert_output --partial "hug h restore"
 }
+
+# ============================================================================
+# #229 Phase-1 enforcement: forward-mover headline + per-site strict propagation
+# + loud edge-case failures
+# ============================================================================
+# These pin the audit's central guarantees END-TO-END (the library-level twins live in
+# tests/lib/test_hug-upstream.bats). Pre-#229 two defects let errors masquerade as data:
+#   • Defect-1: alignment was a one-directional `count target..HEAD == 0`, which is ALSO
+#     true when HEAD is BEHIND the target — so a FORWARD (descendant) move silently no-op'ed
+#     ("Already at target"). The fix gates on is_aligned (exact SHA equality).
+#   • Defect-2: count_commits_in_range swallowed a failed `git rev-list` into `echo 0`, so an
+#     invalid ref / missing upstream looked like an empty range ('0 commits' / 'Already synced',
+#     exit 0). The fix removed the swallow; every strict call site propagates non-zero.
+#
+# These pin the USER-VISIBLE guarantee (non-zero exit, never a silent no-op), NOT the exact strict
+# site. That mechanism is isolated one layer down by the primitive canary at
+# tests/lib/test_hug-git-commit.bats (count_commits_in_range strictness) — mutation-testing shows
+# re-adding the swallow merely RELOCATES the failure downstream (helper-tail `git diff --stat`,
+# `git rev-parse --short <garbage>`, `git rev-parse HEAD` on unborn HEAD), so these stay green by
+# design. Read them as "the command fails loudly," not "this specific line propagates."
+
+@test "hug h back <descendant>: moves HEAD FORWARD instead of no-op'ing (#229 headline)" {
+  # Defect-1, end-to-end. Build A/B/C (the fixture), record the tip C as the forward target,
+  # then move HEAD back to A so C is a true DESCENDANT of HEAD. Pre-fix this printed
+  # "Already at target" and left HEAD at A; post-fix the mover must walk HEAD forward to C.
+  local descendant
+  descendant=$(git rev-parse HEAD)   # capture the tip BEFORE moving — the forward target (C)
+  git reset -q --hard HEAD~2         # HEAD -> A (root); tree clean, descendant is ahead of HEAD
+
+  run env HUG_FORCE=true hug h back "$descendant"
+
+  assert_success
+  refute_output --partial "Already at target"          # the no-op guard must NOT fire for a forward target
+  [ "$(git rev-parse HEAD)" = "$descendant" ]          # HEAD actually moved FORWARD to the descendant
+}
+
+@test "hug h squash <invalid-ref>: rejected loudly (garbage ref) (#229)" {
+  # Garbage-ref rejection pin — NOT a Defect-2 regression pin. h-squash runs ensure_ancestor_of_head
+  # (ensure_commit_exists) BEFORE any count, and that guard predates #229, so an unresolvable ref is
+  # rejected up front: this command path never had a '0 commits' Defect-2 no-op history. The strict
+  # count site (git-h-squash:183) is defense-in-depth only — an ancestor-validated target can never
+  # fail rev-list, so it does not fire here. Guarantee pinned: a bad ref exits non-zero, loudly.
+  run env HUG_FORCE=true hug h squash NO_SUCH_REF_XYZ
+  assert_failure
+}
+
+@test "hug h files -u with no upstream: exits non-zero (strict), not silent (#229)" {
+  # Defect-2, command-level. The fixture has NO upstream, so get_upstream_commit exits non-zero
+  # (git-h-files:120) before the strict count site (git-h-files:125) is even reached. Pins the
+  # missing-upstream path as a loud failure rather than a silent empty preview.
+  run hug h files -u
+  assert_failure
+}
+
+@test "hug h back <garbage-target>: loud failure, never a silent 'Already at target' (#229)" {
+  # Defect-2 edge case. A non-resolving target through a mover: is_aligned(garbage, HEAD) is false
+  # (commits_ahead_behind fails -> non-zero), so handle_standard_operation proceeds to the strict
+  # count, which propagates the rev-list failure -> non-zero. Pre-fix the swallow produced
+  # '0 commits' -> "Already at target" with exit 0. NOTE: this runs at the 3-commit fixture (NOT
+  # root) — at a VALID root a non-resolving target instead takes the reset_root_commit path.
+  run env HUG_FORCE=true hug h back "definitely-not-a-ref-12345"
+  assert_failure
+  refute_output --partial "Already at target"
+}
+
+@test "hug h back recovering at root (unborn HEAD): loud failure, not a silent no-op (#229)" {
+  # Defect-2 edge case (spec §6): recovery at root is a GUARANTEED LOUD FAILURE. Once the root
+  # commit is undone, HEAD is UNBORN and every `git rev-list … HEAD` fails; the now-strict
+  # count_commits_in_range propagates that non-zero instead of swallowing it to 0 (which pre-fix
+  # rendered a misleading "Already at target" no-op). is_aligned(target, unborn-HEAD) is a
+  # false-NEGATIVE (never a false positive), so the mover falls through to the strict count and
+  # fails loudly.
+  #
+  # LESSON / why the input is NOT `h back 1` at a valid root: that input takes git-h-back's
+  # dedicated reset_root_commit branch and SUCCEEDS ("root commit undone", HEAD unborn) — already
+  # pinned above by "hug h back: undoes root commit, files stay staged". A naive
+  # `h back 1 at valid root -> assert_failure` is therefore WRONG; the genuine loud-failure state
+  # is the UNBORN HEAD reproduced here via `git update-ref -d HEAD` (what reset_root_commit runs).
+  local root_sha
+  root_sha=$(git rev-list --max-parents=0 HEAD)        # resolve while HEAD is still born
+  git update-ref -d HEAD                               # -> unborn HEAD: the post-root-undo recovery state
+
+  run env HUG_FORCE=true hug h back "$root_sha"
+
+  assert_failure
+  refute_output --partial "Already at target"          # must fail loudly, not no-op silently
+}

--- a/tests/unit/test_head.bats
+++ b/tests/unit/test_head.bats
@@ -2184,7 +2184,7 @@ EOF
 # tests/lib/test_hug-upstream.bats). Pre-#229 two defects let errors masquerade as data:
 #   • Defect-1: alignment was a one-directional `count target..HEAD == 0`, which is ALSO
 #     true when HEAD is BEHIND the target — so a FORWARD (descendant) move silently no-op'ed
-#     ("Already at target"). The fix gates on is_aligned (exact SHA equality).
+#     ("Already at target"). The fix gates on is_same_commit (exact SHA equality).
 #   • Defect-2: count_commits_in_range swallowed a failed `git rev-list` into `echo 0`, so an
 #     invalid ref / missing upstream looked like an empty range ('0 commits' / 'Already synced',
 #     exit 0). The fix removed the swallow; every strict call site propagates non-zero.
@@ -2230,8 +2230,8 @@ EOF
 }
 
 @test "hug h back <garbage-target>: loud failure, never a silent 'Already at target' (#229)" {
-  # Defect-2 edge case. A non-resolving target through a mover: is_aligned(garbage, HEAD) is false
-  # (commits_ahead_behind fails -> non-zero), so handle_standard_operation proceeds to the strict
+  # Defect-2 edge case. A non-resolving target through a mover: is_same_commit(garbage, HEAD) is false
+  # (rev-parse --verify fails -> non-zero), so handle_standard_operation proceeds to the strict
   # count, which propagates the rev-list failure -> non-zero. Pre-fix the swallow produced
   # '0 commits' -> "Already at target" with exit 0. NOTE: this runs at the 3-commit fixture (NOT
   # root) — at a VALID root a non-resolving target instead takes the reset_root_commit path.
@@ -2244,7 +2244,7 @@ EOF
   # Defect-2 edge case (spec §6): recovery at root is a GUARANTEED LOUD FAILURE. Once the root
   # commit is undone, HEAD is UNBORN and every `git rev-list … HEAD` fails; the now-strict
   # count_commits_in_range propagates that non-zero instead of swallowing it to 0 (which pre-fix
-  # rendered a misleading "Already at target" no-op). is_aligned(target, unborn-HEAD) is a
+  # rendered a misleading "Already at target" no-op). is_same_commit(target, unborn-HEAD) is a
   # false-NEGATIVE (never a false positive), so the mover falls through to the strict count and
   # fails loudly.
   #


### PR DESCRIPTION
✅ Kill the `count == 0 ⟹ aligned` idiom in `count_commits_in_range` and its callers (elifarley/hug-scm#229). The helper is a one-directional ahead-count, but `handle_standard_operation` read `== 0` as "aligned", so `hug h back <descendant-SHA>` silently no-op'd ("Already at target", HEAD unmoved): `== 0` also holds when HEAD is behind the target. That was the root cause of elifarley/hug-scm#222's Critical #1.

✅ Two primitives replace the idiom: `is_same_commit` (exact SHA equality, the only sanctioned identity test) and `commit_offset` (signed distance where 0 is identity by construction, with a distinct exit for diverged and one for error, so a failed rev-list can never surface as a false zero). The `|| echo 0` swallow is gone; strict propagation everywhere.

🟢 Low risk: all 9 call sites audited and classified; `git cmv` deliberately keeps its `== 0` guard (its target must be an ancestor). 263 targeted tests green.

More context: https://github.com/elifarley/hug-scm/issues/229

## The primitives

```bash
is_same_commit "$target" HEAD && { echo "at target"; exit 0; }   # pure boolean identity

offset=$(commit_offset "$target" HEAD); rc=$?                     # signed distance
case $rc in
  0) echo "offset: $offset" ;;   # identity (0) or a clean distance (N ahead / -N behind)
  2) echo "diverged" ;;          # incomparable histories (distinct exit)
  *) echo "bad ref" ;;           # exit 3: unresolvable
esac
```

| Primitive | Returns | Use for |
|---|---|---|
| `is_same_commit A B` | exit 0 iff same commit; non-zero on invalid ref or unborn HEAD (false-negative, never false-positive) | yes/no alignment, the ONLY sanctioned test |
| `commit_offset A [B=HEAD]` | `0` identity · `N` B ahead · `-N` B behind (all exit 0); empty+exit 2 diverged; empty+exit 3 bad ref | alignment PLUS direction/magnitude |
| `count_commits_in_range S [E]` | one-directional ahead-count, strict (non-zero/empty on failure) | counting only, never an alignment decision |
| `count_commits_in_range_or_zero S [E]` | the wrapper, cosmetic 0 on failure | display only (grep canary: exactly 1 hit in the tree) |

**Kept deliberate:** `git cmv` retains its `== 0` guard. Its target must be an ancestor, so `== 0` is the correct vacuous-op test there; migrating it to `is_same_commit` would fall through to a forward move on a NOT-RESTORABLE command. Its message now branches on `is_same_commit` to stay truthful (aligned: "already at"; descendant: "needs an ancestor target").

<details><summary>Details</summary>

## Root cause

`count_commits_in_range` wraps `git rev-list --count start..end`, a ONE-directional ahead-count. `== 0` means "end is not ahead of start", which is ALSO true when end is BEHIND start. `handle_standard_operation` used it as an alignment test, so a forward (descendant) target read as "already at target" and the mover silently no-op'd (exit 0, HEAD unmoved): the mechanism behind elifarley/hug-scm#222's Critical #1.

Two defects compounded:

1. Alignment conflation: `count == 0` used as "aligned" when it means "not ahead".
2. Failure swallow: `|| echo 0` turned a rev-list failure (garbage ref, unborn HEAD) into a valid-looking zero, which then read as "aligned". A bad ref was indistinguishable from at-target.

## The fix

- `is_same_commit`: `git rev-parse --verify --quiet X^{commit}` on both refs + string equality. No rev-list traversal; the equality test is the last command so its exit status propagates. Invalid ref or unborn HEAD gives a false NEGATIVE, never a false positive (movers guard repo/commit existence first, and the loud-failure chain holds regardless).
- `commit_offset`: SHA-equality short-circuit makes 0 IDENTITY by construction (the false-zero is unrepresentable). Otherwise `git rev-list --left-right --count a...b` maps to N / -N; diverged is empty+exit 2; an unresolvable ref OR a post-rev-parse traversal failure is empty+exit 3. The `read` carries `|| return 3` so a traversal failure cannot fall through to the diverged exit.
- `count_commits_in_range` strictified: `|| echo 0` removed, `${1:?}` guard added, failures propagate (non-zero exit, empty stdout).
- `count_commits_in_range_or_zero`: the ONE sanctioned cosmetic-0 wrapper, for display sites only. A grep canary pins it to exactly 1 hit in the tree; the contract-table comments deliberately avoid the literal pipe-form so they do not trip it.

## Call sites (all 9 audited)

- `handle_standard_operation` (hug-git-upstream): guard `count == 0` to `is_same_commit` (the Defect-1 core fix; forward targets now move HEAD). Called BARE by the movers, so its `exit 0` terminates them. Preview count strict with `|| return 1`.
- `handle_upstream_operation` (hug-git-upstream): `|| return 1` on its count call. REQUIRED, not cargo-cult: the function is invoked as `target=$(handle_upstream_operation …) || exit $?`, and the `|| exit $?` suspends `set -e` inside the body; without the explicit guard a failed count would flow into a destructive operation with a broken preview.
- `git-cmv`: strict (`|| exit 1`) + branched truthful message; KEPT the `== 0` vacuous-op guard (see above).
- `git-h-restore`: adopted `is_same_commit`; rewrote stale `count==0` comments (incl. the h-back/h-undo root-path comments, now "loud failure", since rev-list failing at the root propagates rather than reading as aligned).
- `git-log-outgoing`, `git-h-files`, `git-h-squash`: explicit `|| exit 1` at the remaining top-level strict callers. `git-h-squash`'s `== 0` branch is LIVE (merge-base treats a commit as its own ancestor) and is preserved with a pin test.
- `hug-git-rebase` + `git-h-files` display site: migrated to `count_commits_in_range_or_zero`.

## Naming: matches the issue author's vision

The final primitives ARE the issue-comment refinements from elifarley/hug-scm#229 (comment 3): `is_same_commit` + `commit_offset` (signed distance, diverged as a distinct exit code). An earlier draft of this PR carried interim names (`is_aligned`, `commits_ahead_behind`); the tree was realigned to the author's exact shapes in 2f3d5e8. This PR now implements the issue's proposed contract, not a divergent one.

## Tests

263 targeted: 43 primitive (incl. commit_offset identity/ahead/behind/diverged/error paths, pinned with `--separate-stderr`), 10 upstream (Defect-1 forward-mover regression + aligned guard), 157 head (forward-mover smoke, squash live-branch pin, per-site strict propagation, root-recovery + garbage-target edge cases), 18 restore, 35 cmv. The grep canary (`grep -rn '|| echo 0' git-config/` = 1 hit) and Phase-2-absence grep are verified. Full suite: 3278 tests, 2 documented pre-existing environmental failures (`.env` gitignore in test_hug-file-input, git-identity sanitization in `hug c`), both reproduced identically on `main`, neither related to this PR.

## Phase 2 deferred

Direction-truthful messaging (making the movers say "Moved HEAD forward" instead of "back" for a forward move) is a separate spec: `docs/superpowers/specs/2026-07-30-head-mover-direction-messaging-design.md`. Verified absent from this PR.

</details>

