### PR TITLE
fix: head-mover correctness batch — loud invalid/forward-target rejection (#234) + truthful behind-upstream messaging (#237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Hug SCM project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **`h back`/`h undo`/`h rollback` reject invalid and forward explicit targets loudly** — a garbage target could previously trigger the root-recovery path (undoing the root commit on nonsense input), and a forward target moved HEAD through a backward-named command; both now error, with forward targets pointing at `hug h restore <target> --<op>` (elifarley/hug-scm#234). Root-recovery is now reachable only with no positional target.
+
+- **`commit_offset`'s Usage docstring corrected to the errexit-safe capture idiom** (`offset=$(…) || rc=$?`) — the previous form (capture, then read the status on the next line) is dead code under `set -e` for exactly the exit codes the dispatch exists to distinguish (related: elifarley/hug-scm#234).
+
+### Changed
+
+- **`-u` operations report "N commit(s) behind upstream" instead of the false "Already synced" when HEAD is behind upstream** — aligned keeps its message; the exit-0 no-op contract is unchanged (elifarley/hug-scm#237).
+
 ## [1.5.0] - 2026-08-06
 
 ### Added
@@ -83,8 +95,6 @@ All notable changes to the Hug SCM project will be documented in this file.
 
 - **`hug c` stderr chatter string changed** from `Committing staged changes...` to `Committing staged file(s) (N):` (followed by file names). Any external script grepping `hug c` stderr for the old string will need to update its pattern. The new string is richer (count + names) and arrives BEFORE the commit lands, enabling recovery.
 - **`hug a` adds a new stderr line** (`Staged N file(s). Index now has M file(s) staged total.`) after every successful stage. External scripts parsing `hug a` stderr may see the new line; stdout is unchanged.
-
-## [Unreleased]
 
 ### Fixed
 

--- a/docs/commands/head.md
+++ b/docs/commands/head.md
@@ -122,7 +122,7 @@ All HEAD movement commands (`hug h back`, `hug h undo`, `hug h rollback`, `hug h
 - **RESTORE**: h-squash is inverted by `hug h restore <pre-op-HEAD> --back -y`. After a successful operation, Hug prints this exact command with the pre-op SHA filled in. `--back` selects `git reset --soft`, which moves HEAD without touching the index -- the squashed commit's content stays staged. Pre-existing staged changes will be included - review with `hug ss` first.
 
 ### `hug h restore <SHA> --back|--undo|--rollback|--rewind [-y, --yes] [-f, --force] [--quiet] [-h, --help]`
-- **Description**: Recovery primitive that resets HEAD to a specific commit, inverting a prior HEAD-mover operation. Unlike re-invoking the mover (which would short-circuit on the aligned-target check), `hug h restore` uses exact-SHA equality for its no-op test, allowing it to move HEAD **forward** to a descendant commit. The flag (`--back`/`--undo`/`--rollback`/`--rewind`) selects the `git reset` **mode** -- it does NOT encode direction; direction is determined solely by the target's position relative to HEAD.
+- **Description**: Recovery primitive that resets HEAD to a specific commit, inverting a prior HEAD-mover operation. Unlike re-invoking the mover (backward movers reject a forward target loudly — `hug h back <descendant>` errors and points here), `hug h restore` is the sanctioned forward mover: its no-op test is exact-SHA equality, never a range count, so it can move HEAD **forward** to a descendant commit. The flag (`--back`/`--undo`/`--rollback`/`--rewind`) selects the `git reset` **mode** -- it does NOT encode direction; direction is determined solely by the target's position relative to HEAD.
 - **Required**: An op-mode flag (exactly one) and a target SHA. The target must not be a bare 1--3 digit numeric (ambiguous -- reads as `HEAD~N`); use a 4+ char SHA prefix or explicit `HEAD~N`.
 - **Flags**:
   - `--back`: `git reset --soft` -- moves HEAD, keeps changes staged. For h-back / h-squash recovery.
@@ -156,7 +156,7 @@ All HEAD movement commands (`hug h back`, `hug h undo`, `hug h rollback`, `hug h
 
 ### Why a dedicated recovery command?
 
-Re-invoking a HEAD-mover (e.g., `hug h back abc123`) to recover forward **does not work** -- the mover's aligned-target check (`count_commits_in_range target HEAD == 0`) short-circuits to a no-op whenever the target is a descendant of HEAD. Since the pre-op HEAD is always ahead after a successful backward move, any re-invocation of the mover silently exits 0 without moving HEAD.
+Re-invoking a HEAD-mover (e.g., `hug h back abc123`) to recover forward **does not work** — backward movers validate direction: a descendant target is rejected with a loud error ("…is ahead of HEAD by N commit(s)… use `hug h restore <target> --<op>` to move forward"), because a forward move through a backward-named command is a direction mistake. Since the pre-op HEAD is always ahead after a successful backward move, forward recovery goes through `hug h restore`.
 
 `hug h restore` solves this with two design decisions:
 

--- a/docs/superpowers/plans/2026-08-06-head-mover-correctness-batch.md
+++ b/docs/superpowers/plans/2026-08-06-head-mover-correctness-batch.md
@@ -1,0 +1,683 @@
+# Head-Mover Correctness Batch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make explicit garbage/forward targets in `h back`/`h undo`/`h rollback` fail loudly instead of triggering root-recovery (#234), make `-u` operations report "behind upstream" truthfully instead of "Already synced" (#237), and pin/correct the hygiene residue (#235/#236/#239).
+
+**Architecture:** One shared validator (`validate_backward_target`) in `git-config/lib/hug-git-upstream`, built on `commit_offset`'s four-outcome dispatch (garbage→error, diverged→silent pass/sideways, ahead→error with restore hint, ancestor/self→pass), wired into the three movers' non-upstream paths with a structural `-z target_arg` root-guard tightening. The §2 fix replaces the `== 0` branch of `handle_upstream_operation` with an aligned-vs-behind split. Spec: `docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md` (read it first — it carries the binding decisions).
+
+**Tech Stack:** Bash (`set -euo pipefail`), BATS test suite via `make test-*` targets, hug CLI.
+
+**Worktree:** ALL work happens in `/home/ecc/src/hug-scm.WT.mover-correctness-batch` (branch `mover-correctness-batch`). Prefix every shell command with `cd /home/ecc/src/hug-scm.WT.mover-correctness-batch &&` (the harness clamps CWD between commands).
+
+**House rules that apply to every task:**
+- NEVER write the literal two-character pipe + `echo 0` swallow form into comments — the canary `grep -rn '|| echo 0' git-config/` must stay at exactly 1 hit.
+- Inside functions, NEVER merge declaration+capture (`local x=$(cmd)` masks failure); declare then assign.
+- Never use `local` outside a function body.
+- Commits: `hug a <files>` then `hug c -F -` with a WHY/WHAT/HOW/IMPACT body (load the `commit-message` skill).
+- Tests run ONLY via `make test-*` targets.
+
+---
+
+### Task 1: `validate_backward_target` helper + library tests (#234 core)
+
+**Goal:** Add the shared backward-target validator to `git-config/lib/hug-git-upstream`, TDD'd at the library layer.
+
+**Files:**
+- Modify: `git-config/lib/hug-git-upstream` (insert after `handle_standard_operation`, before the "Root Commit Operations" banner at ~:159)
+- Test: `tests/lib/test_hug-upstream.bats` (new section at the end)
+
+**Acceptance Criteria:**
+- [ ] garbage target → failure with `'X' is not a valid commit`
+- [ ] forward target → failure with `is ahead of HEAD by N commit(s)` and a pasteable `hug h restore <target> --<op>` hint
+- [ ] diverged target → silent pass (exit 0, empty output) — sideways moves preserved
+- [ ] ancestor and self targets → silent pass
+- [ ] capture idiom is `local rc=0` + `offset=$(commit_offset …) || rc=$?` (assignment left of `||`); the catch-all arm is an `error`, not a bare return
+
+**Verify:** `make test-lib TEST_FILE=test_hug-upstream.bats` → all pass (10 existing + 4 new)
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/lib/test_hug-upstream.bats`:
+
+```bash
+################################################################################
+# validate_backward_target: #234 — explicit targets must be valid BACKWARD moves
+################################################################################
+# NOTE on test layers: bats `run` DISABLES errexit, so these helper-layer tests would
+# pass green even on a capture idiom broken under set -e. The mover-layer e2e tests in
+# tests/unit/test_head.bats (real scripts under set -euo pipefail) are the layer that
+# catches that — do not delete them in favor of these.
+
+@test "validate_backward_target: garbage target -> 'not a valid commit', non-zero" {
+  run validate_backward_target "definitely-not-a-ref" "back"
+  assert_failure
+  assert_output --partial "'definitely-not-a-ref' is not a valid commit"
+}
+
+@test "validate_backward_target: forward (descendant) target -> 'ahead of HEAD' + pasteable restore hint" {
+  local descendant; descendant=$(git rev-parse HEAD)
+  git update-ref HEAD HEAD~1                  # plumbing: HEAD back one, descendant now ahead
+  run validate_backward_target "$descendant" "back"
+  assert_failure
+  assert_output --partial "is ahead of HEAD by 1 commit(s)"
+  assert_output --partial "hug h restore $descendant --back"
+}
+
+@test "validate_backward_target: diverged target -> silent pass (sideways move preserved)" {
+  git checkout -q -b diverger                 # branch at HEAD
+  echo "d" > diverger.txt; git add diverger.txt; git commit -q -m "branch diverges"
+  git checkout -q -                           # back to the original branch
+  echo "l" > local-only.txt; git add local-only.txt; git commit -q -m "HEAD diverges"
+  run validate_backward_target "diverger" "undo"
+  assert_success
+  [ -z "$output" ]                            # silent: today's sideways behavior, NOT an error
+}
+
+@test "validate_backward_target: ancestor and self -> silent pass" {
+  run validate_backward_target "HEAD~1" "back"
+  assert_success
+  [ -z "$output" ]
+  local self; self=$(git rev-parse HEAD)
+  run validate_backward_target "$self" "back"
+  assert_success
+  [ -z "$output" ]
+}
+```
+
+- [ ] **Step 2: Run to verify they fail** — `make test-lib TEST_FILE=test_hug-upstream.bats` → 4 failures with `command not found: validate_backward_target` (bats surfaces the missing function as failure).
+
+- [ ] **Step 3: Implement the helper** — insert into `git-config/lib/hug-git-upstream` between `handle_standard_operation` and the Root Commit Operations banner:
+
+```bash
+# Validates an EXPLICIT target for a backward HEAD-mover (h-back / h-undo / h-rollback).
+# Usage: validate_backward_target <target> <op> [<user_input>]
+# Parameters:
+#   $1 - resolved target (may be the raw ref if resolution failed upstream)
+#   $2 - mover name for messages: "back" | "undo" | "rollback"
+#   $3 - (Optional) the user's LITERAL input, quoted in error messages (defaults to $1)
+#
+# Contract — keep ISOMORPHIC to commit_offset's outcome table (hug-git-commit):
+#   unresolvable (exit 3)   -> error "'<input>' is not a valid commit", non-zero
+#   diverged     (exit 2)   -> silent pass — a valid SIDEWAYS move; today's behavior, NOT an error
+#   ahead        (offset<0) -> error "…is ahead of HEAD by N commit(s)…", non-zero
+#   self/ancestor (offset>=0)-> silent pass
+#
+# WHY this gate exists (#234): pre-fix, an unresolvable explicit target at the root commit
+# was indistinguishable from the legitimate "no parent of root" case, so `hug h back garbage`
+# triggered reset_root_commit — the most destructive path — on nonsense input. Callers ALSO
+# tighten their root-path guard to `[[ -z "$target_arg" ]]` (defense in depth).
+validate_backward_target() {
+    local target="$1" op="${2:?validate_backward_target: op required}" user_input="${3:-$1}"
+    local offset rc=0
+    # Capture via `|| rc=$?` — the assignment MUST sit left of `||`: a bare
+    # `offset=$(commit_offset …)` aborts a `set -e` caller at the assignment for exit 2/3,
+    # before the dispatch below can run (same failure class as the local-x-capture masking).
+    offset=$(commit_offset "$target" HEAD) || rc=$?
+    case $rc in
+      3) error "'$user_input' is not a valid commit" ;;
+      2) return 0 ;;   # diverged: valid sideways move — today's behavior, NOT an error
+      0) ;;
+      # unreachable today (commit_offset's exit surface is total over {0,2,3}) — but an
+      # `error`, not a bare return: a bare non-zero return would surface as a MESSAGELESS
+      # errexit abort, the opposite of this batch's loud-failure promise.
+      *) error "internal error: commit_offset returned unexpected status $rc for '$user_input'" ;;
+    esac
+    if [ "$offset" -lt 0 ]; then
+        error "hug h $op moves HEAD back, but '$user_input' is ahead of HEAD by ${offset#-} commit(s) (use 'hug h restore $user_input --$op' to move forward)"
+    fi
+}
+```
+
+- [ ] **Step 4: Run to verify they pass** — `make test-lib TEST_FILE=test_hug-upstream.bats` → all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+hug a git-config/lib/hug-git-upstream tests/lib/test_hug-upstream.bats
+```
+Message subject: `feat(lib): validate_backward_target — loud failure for garbage/forward explicit targets (#234)` with WHY/WHAT/HOW/IMPACT body (WHY: garbage at root triggered reset_root_commit; WHAT: shared commit_offset-based validator, four-outcome dispatch; HOW: `|| rc=$?` capture idiom, isomorphic contract table; IMPACT: movers wire it in the next commits).
+
+---
+
+### Task 2: Wire the validator into h-back + full mover-level matrix
+
+**Goal:** Wire `validate_backward_target` into `git-h-back`, tighten the root guard, and pin the behavior change end-to-end — including FLIPPING the #229 forward-headline test (forward explicit targets now error instead of proceeding; spec §1 decision).
+
+**Files:**
+- Modify: `git-config/bin/git-h-back` (~:93-96)
+- Test: `tests/unit/test_head.bats`
+
+**Acceptance Criteria:**
+- [ ] wiring line inserted after `resolve_target_with_temporal` in the non-upstream branch: `[[ -n "$target_arg" ]] && validate_backward_target "$target" "back" "$target_arg"`
+- [ ] root-path guard now begins `[[ -z "$target_arg" ]] &&`
+- [ ] garbage at root → loud failure, root commit intact
+- [ ] `h back 1` at root → loud failure quoting the literal `'1'` (behavior change, documented)
+- [ ] no-arg at root → root-recovery unchanged (existing test stays green)
+- [ ] forward/descendant explicit target → loud failure pointing at restore (headline flipped)
+- [ ] diverged orphan ref at root → proceeds (sideways move preserved)
+
+**Verify:** `make test-unit TEST_FILE=test_head.bats` → all green (the suite count changes: +4 new, 1 rewritten)
+
+**Steps:**
+
+- [ ] **Step 1: Write/rewrite the mover-level tests** in `tests/unit/test_head.bats`.
+
+(a) REWRITE the existing test `"hug h back <descendant>: moves HEAD FORWARD instead of no-op'ing (#229 headline)"` (~:2201) — the batch deliberately narrows this guarantee (spec §1: forward explicit targets are a direction mistake; restore is the sanctioned forward mover):
+
+```bash
+@test "hug h back <descendant>: rejected loudly, points at restore (#234 narrows the #229 headline)" {
+  # Evolution: #229 made forward targets PROCEED through the movers; the #234 batch narrows
+  # that — a FORWARD explicit target through a backward-NAMED mover is a direction mistake,
+  # rejected loudly and pointing at restore (the sanctioned forward mover, which encodes the
+  # reset mode explicitly). A silent forward move through a command named "back" surprised
+  # users; restore is unambiguous.
+  local descendant
+  descendant=$(git rev-parse HEAD)   # capture the tip BEFORE moving — the forward target (C)
+  git reset -q --hard HEAD~2         # HEAD -> A (root); tree clean, descendant is ahead of HEAD
+
+  run env HUG_FORCE=true hug h back "$descendant"
+
+  assert_failure
+  assert_output --partial "is ahead of HEAD by 2 commit(s)"
+  assert_output --partial "hug h restore"
+  refute_output --partial "Already at target"
+  [ "$(git rev-parse HEAD)" != "$descendant" ]   # HEAD did NOT move
+}
+```
+
+(b) REWRITE the stale LESSON comment in `"hug h back recovering at root (unborn HEAD)…"` (~:2251): replace the paragraph starting "LESSON / why the input is NOT `h back 1` at a valid root: that input takes git-h-back's dedicated reset_root_commit branch and SUCCEEDS" with:
+
+```
+  # LESSON / `h back 1` at a VALID root: since the #234 batch an explicit target is validated
+  # FIRST — `h back 1` (HEAD~1, unresolvable at root) fails loudly with "'1' is not a valid
+  # commit" (pinned below). The root-recovery branch is now reachable ONLY with no positional
+  # target (the `-z target_arg` structural guard), and the no-arg form stays pinned by
+  # "hug h back: undoes root commit, files stay staged".
+```
+
+(c) APPEND new tests (same file, after the #229 enforcement section):
+
+```bash
+# ============================================================================
+# #234 enforcement: explicit targets are validated — garbage/forward fail loudly,
+# sideways (diverged) proceeds, root-recovery is no-arg-only
+# ============================================================================
+
+@test "hug h back <garbage> at root: loud failure, root commit intact (#234)" {
+  # THE reason this batch exists: pre-fix, a garbage explicit target at root was
+  # indistinguishable from "no parent of root" and triggered reset_root_commit.
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+  local root_sha; root_sha=$(git rev-parse HEAD)
+
+  run env HUG_FORCE=true hug h back definitely-not-a-ref
+
+  assert_failure
+  assert_output --partial "'definitely-not-a-ref' is not a valid commit"
+  [ "$(git rev-parse HEAD)" = "$root_sha" ]   # the destructive path never ran
+}
+
+@test "hug h back 1 at root: loud failure quoting the user's literal (#234 behavior change)" {
+  # HEAD~1 does not exist at root. Pre-fix this triggered root-recovery; an explicit target
+  # is a user assertion, so it now fails loudly — quoting what the user TYPED ('1'), not the
+  # internally-resolved HEAD~1 (the validator receives the literal input).
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+
+  run env HUG_FORCE=true hug h back 1
+
+  assert_failure
+  assert_output --partial "'1' is not a valid commit"
+}
+
+@test "hug h back <diverged-orphan-ref> at root: silent pass, sideways move preserved (#234)" {
+  # Orphan branches DO diverge from the root (no common ancestor) — the "diverged at root"
+  # shape is reachable. Policy: silent pass; today's sideways preview/reset, unchanged.
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+  local other_root; other_root=$(git rev-parse HEAD)
+  git checkout -q --orphan sideway
+  echo "s" > sideways.txt; git add sideways.txt; git commit -q -m "orphan root"
+
+  run env HUG_FORCE=true hug h back "$other_root"
+
+  assert_success
+  [ "$(git rev-parse HEAD)" = "$other_root" ]   # sideways reset happened
+}
+
+@test "hug h back <diverged-branch>: proceeds (THE errexit-detection assertion) (#234)" {
+  # CRITICAL layer: this runs the REAL mover under set -euo pipefail. A broken capture idiom
+  # (offset=$(commit_offset …); rc=$?) dies silently at the assignment for exit 2; bats `run`
+  # at the HELPER layer cannot catch that (run disables errexit). This assertion — diverged
+  # target PROCEEDS instead of exiting silently — is the batch's only defense against a
+  # regression of the capture idiom.
+  create_test_repo_with_history
+  git checkout -q -b advanced-branch
+  echo "adv" > advanced.txt; git add advanced.txt; git commit -q -m "branch advances"
+  git checkout -q -
+  echo "loc" > local-advance.txt; git add local-advance.txt; git commit -q -m "HEAD advances"
+  local target; target=$(git rev-parse advanced-branch)   # diverged from HEAD
+
+  run env HUG_FORCE=true hug h back advanced-branch
+
+  assert_success
+  [ "$(git rev-parse HEAD)" = "$target" ]                 # sideways move, NOT a silent exit
+}
+```
+
+- [ ] **Step 2: Run to verify the new/rewritten tests fail** — `make test-unit TEST_FILE=test_head.bats TEST_FILTER="#234"` → the four new tests fail (validator not wired); the flipped headline fails (forward still proceeds).
+
+- [ ] **Step 3: Wire the validator** in `git-config/bin/git-h-back`. In the `else` (non-upstream) branch, after the `resolve_target_with_temporal` line (~:93), insert:
+
+```bash
+  # #234: an EXPLICIT target must be a valid BACKWARD move — garbage fails loudly (never a
+  # root-recovery on nonsense input) and a forward target points at restore instead of moving
+  # HEAD through a backward-named command. The default HEAD~1 is skipped by design: at root it
+  # legitimately does not resolve — that unresolved default IS the root-recovery trigger below.
+  [[ -n "$target_arg" ]] && validate_backward_target "$target" "back" "$target_arg"
+```
+
+and tighten the root-path guard (~:96) from
+
+```bash
+  if ! git rev-parse --verify --quiet "$target" > /dev/null 2>&1 && is_at_root_commit; then
+```
+
+to
+
+```bash
+  if [[ -z "$target_arg" ]] && ! git rev-parse --verify --quiet "$target" > /dev/null 2>&1 && is_at_root_commit; then
+```
+
+(Defense in depth: root-recovery becomes structurally unreachable for ANY explicit target, even if the validator is later refactored.)
+
+- [ ] **Step 4: Run the whole head suite** — `make test-unit TEST_FILE=test_head.bats` → all green. If the no-arg root-recovery test ("hug h back: undoes root commit, files stay staged") fails, the `-z target_arg` clause or wiring position is wrong — fix before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+hug a git-config/bin/git-h-back tests/unit/test_head.bats
+```
+Message subject: `fix(h-back): loud failure for garbage/forward explicit targets; root-recovery is no-arg-only (#234)` — WHY/WHAT/HOW/IMPACT body (WHY: garbage at root triggered the most destructive path; WHAT: validator wiring + `-z target_arg` guard + headline flip; HOW: validator-first + structural clause, defense in depth; IMPACT: root commit is unreachable from nonsense input).
+
+---
+
+### Task 3: Wire h-undo + h-rollback; sibling spot-checks; the documented everyday shape
+
+**Goal:** Same wiring in the two sibling movers (op names `"undo"`/`"rollback"`), with spot-checks and the `hug h undo main` sideways-PROCEEDS assertion.
+
+**Files:**
+- Modify: `git-config/bin/git-h-undo` (~:103-106), `git-config/bin/git-h-rollback` (~:98-101)
+- Test: `tests/unit/test_head.bats`
+
+**Acceptance Criteria:**
+- [ ] both movers carry the identical wiring with their own op literal (`"undo"` / `"rollback"`)
+- [ ] both root guards carry the `[[ -z "$target_arg" ]] &&` clause
+- [ ] garbage at root fails loudly for each mover (error text names the mover's own op)
+- [ ] `hug h undo <advanced-branch>` (diverged) proceeds — the documented `hug h undo main` everyday shape
+
+**Verify:** `make test-unit TEST_FILE=test_head.bats` → all green
+
+**Steps:**
+
+- [ ] **Step 1: Append the spot-check tests** to `tests/unit/test_head.bats`:
+
+```bash
+@test "hug h undo <garbage> at root: loud failure, mover named correctly (#234 spot-check)" {
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+  run env HUG_FORCE=true hug h undo nope-ref
+  assert_failure
+  assert_output --partial "'nope-ref' is not a valid commit"
+}
+
+@test "hug h rollback <garbage> at root: loud failure, mover named correctly (#234 spot-check)" {
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+  run env HUG_FORCE=true hug h rollback nope-ref
+  assert_failure
+  assert_output --partial "'nope-ref' is not a valid commit"
+}
+
+@test "hug h undo <diverged-branch>: proceeds (the documented 'hug h undo main' shape) (#234)" {
+  # docs/commands/head.md ships `hug h undo main` as an everyday example; on a branch whose
+  # main has advanced, the target is DIVERGED. The batch must preserve today's sideways
+  # preview/reset — a silent non-zero exit here would regress the everyday shape.
+  create_test_repo_with_history
+  git checkout -q -b advanced-main
+  echo "adv" > advanced.txt; git add advanced.txt; git commit -q -m "main advances"
+  git checkout -q -
+  echo "loc" > local-advance.txt; git add local-advance.txt; git commit -q -m "HEAD advances"
+  local target; target=$(git rev-parse advanced-main)
+
+  run env HUG_FORCE=true hug h undo advanced-main
+
+  assert_success
+  [ "$(git rev-parse HEAD)" = "$target" ]
+}
+```
+
+- [ ] **Step 2: Run to verify they fail** — `make test-unit TEST_FILE=test_head.bats TEST_FILTER="#234 spot-check"` and `TEST_FILTER="documented"` → failures (validators not wired).
+
+- [ ] **Step 3: Wire both movers.** In `git-config/bin/git-h-undo`, after the non-upstream `resolve_target_with_temporal` line (~:103) insert the same comment block as Task 2 Step 3 with op `"undo"`:
+
+```bash
+  [[ -n "$target_arg" ]] && validate_backward_target "$target" "undo" "$target_arg"
+```
+
+and tighten its root guard (~:106) to begin `[[ -z "$target_arg" ]] &&`. Apply the identical pair to `git-config/bin/git-h-rollback` (~:98 wiring with `"rollback"`, ~:101 guard).
+
+- [ ] **Step 4: Run the whole head suite** — `make test-unit TEST_FILE=test_head.bats` → all green (existing no-arg root tests for undo/rollback stay green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+hug a git-config/bin/git-h-undo git-config/bin/git-h-rollback tests/unit/test_head.bats
+```
+Message subject: `fix(h-undo,h-rollback): same explicit-target validation as h-back (#234)`.
+
+---
+
+### Task 4: Truthful sync-state messaging in handle_upstream_operation (#237)
+
+**Goal:** In the `== 0` branch, distinguish aligned ("Already synced", unchanged) from behind ("HEAD is N commit(s) behind upstream … pull or rebase") via `commit_offset` — its first production caller.
+
+**Files:**
+- Modify: `git-config/lib/hug-git-upstream` (`handle_upstream_operation` `== 0` branch, ~:51-54)
+- Test: `tests/lib/test_hug-upstream.bats`
+
+**Acceptance Criteria:**
+- [ ] aligned → `Already synced to upstream (<short>).` + exit 0 (unchanged text)
+- [ ] behind by N → `Nothing to move: HEAD is N commit(s) behind upstream (<branch>). Pull or rebase to catch up.` + exit 0
+- [ ] branch computes `target_short`/`upstream_branch` locally (split declaration/assignment); no unbound variables under `set -u`
+- [ ] all five existing "Already synced" assertions stay green (workflows ×4, test_head ×1)
+
+**Verify:** `make test-lib TEST_FILE=test_hug-upstream.bats` + `make test-integration TEST_FILE=test_workflows.bats` + `make test-unit TEST_FILE=test_head.bats TEST_FILTER="synced"`
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/lib/test_hug-upstream.bats`:
+
+```bash
+################################################################################
+# handle_upstream_operation: truthful aligned-vs-behind messaging (#237)
+################################################################################
+# count(target..HEAD) == 0 means "not AHEAD" — also true when HEAD is BEHIND upstream.
+# Diverged cannot reach the branch (diverged ⇒ ahead > 0), so it is a clean 2-state split.
+
+# Shared fixture: repo + bare origin + push + attached upstream (HEAD synced with origin).
+setup_synced_upstream() {
+  local branch; branch=$(git branch --show-current)
+  REMOTE_REPO=$(mktemp -d)/origin.git
+  git init --bare -q "$REMOTE_REPO"
+  git remote add origin "$REMOTE_REPO"
+  git push -q origin "$branch"
+  git branch --set-upstream-to="origin/$branch" >&2
+}
+
+# Advances origin by N empty commits (via a clone), leaving HEAD BEHIND upstream.
+advance_remote() {
+  local n="$1" clone_dir
+  clone_dir=$(mktemp -d)/clone
+  git clone -q "$REMOTE_REPO" "$clone_dir"
+  local i=1
+  while [ "$i" -le "$n" ]; do
+    git -C "$clone_dir" -c user.email=test@test -c user.name=test \
+        commit -q --allow-empty -m "remote advance $i"
+    i=$((i + 1))
+  done
+  git -C "$clone_dir" push -q origin HEAD
+}
+
+@test "handle_upstream_operation: aligned -> 'Already synced' (unchanged), exit 0 (#237)" {
+  create_test_repo_with_history
+  setup_synced_upstream
+  run handle_upstream_operation "moving back" "warn" "back" "discards local-only commits"
+  assert_success
+  assert_output --partial "Already synced to upstream"
+}
+
+@test "handle_upstream_operation: HEAD BEHIND upstream -> truthful behind message, exit 0 (#237)" {
+  create_test_repo_with_history
+  setup_synced_upstream
+  advance_remote 2
+  run handle_upstream_operation "moving back" "warn" "back" "discards local-only commits"
+  assert_success
+  assert_output --partial "Nothing to move: HEAD is 2 commit(s) behind upstream"
+  assert_output --partial "Pull or rebase to catch up"
+  refute_output --partial "Already synced"
+}
+```
+
+- [ ] **Step 2: Run to verify the behind test fails** — `make test-lib TEST_FILE=test_hug-upstream.bats TEST_FILTER="behind upstream"` → fails (still prints "Already synced").
+
+- [ ] **Step 3: Replace the `== 0` branch** in `handle_upstream_operation` (~:51-54):
+
+```bash
+    if [ "$local_commits" -eq 0 ]; then
+        # == 0 means "not AHEAD": aligned OR behind (diverged is unreachable here —
+        # diverged ⇒ ahead > 0). commit_offset distinguishes exactly these two states;
+        # this is its first production caller (#238).
+        local offset
+        offset=$(commit_offset "$target" HEAD) || return 1
+        local target_short
+        target_short=$(git rev-parse --short "$target")
+        if [ "$offset" -eq 0 ]; then
+            info "Already synced to upstream ($target_short)."
+            exit 0
+        fi
+        local upstream_branch
+        # Parity with the preview block's computation; the fallback cannot actually fire
+        # here (get_upstream_commit already resolved @{u}, which requires an attached HEAD).
+        upstream_branch=$(git for-each-ref --format='%(upstream:short)' "$(git symbolic-ref HEAD)" 2>/dev/null || echo "upstream")
+        info "Nothing to move: HEAD is ${offset#-} commit(s) behind upstream ($upstream_branch). Pull or rebase to catch up."
+        exit 0
+    fi
+```
+
+- [ ] **Step 4: Run all affected suites** — `make test-lib TEST_FILE=test_hug-upstream.bats` (both new tests green) + `make test-integration TEST_FILE=test_workflows.bats` (the 4 synced assertions green) + `make test-unit TEST_FILE=test_head.bats TEST_FILTER="synced"` (the rewind -u assertion green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+hug a git-config/lib/hug-git-upstream tests/lib/test_hug-upstream.bats
+```
+Message subject: `fix(upstream): report 'behind upstream' truthfully instead of 'Already synced' (#237)`.
+
+---
+
+### Task 5: Hygiene trio — pin both guards (#235), README set-e axes (#236), oxymoron (#239)
+
+**Goal:** Pin the load-bearing `|| return 1` guards with function-shadowing stub tests; correct the README's errexit attribution with the two-axis truth; fix the "STRICT-display twin" oxymoron.
+
+**Files:**
+- Test: `tests/lib/test_hug-upstream.bats`
+- Modify: `git-config/lib/README.md` (~:458-461), `git-config/lib/hug-git-commit` (:237)
+
+**Acceptance Criteria:**
+- [ ] stub test 1: with `count_commits_in_range` shadowed to `return 1`, `handle_upstream_operation` fails non-zero with NO preview output; deleting the `|| return 1` at hug-git-upstream:49 turns this test red (verify by temporary removal, then restore)
+- [ ] stub test 2 (symmetry): with `commit_offset` shadowed to `return 1` in a synced repo, the helper fails non-zero with neither synced nor behind message; the new Task-4 guard is pinned
+- [ ] README comment attributes errexit suspension to BOTH axes (mid-body `$(…)` never fires; functions called from a `||` position run errexit-disabled) — not the false blanket "capture does not suspend errexit"
+- [ ] `grep -q 'STRICT-display' git-config/` fails (oxymoron gone); the "NEVER use for a branching or alignment decision" guidance intact
+
+**Verify:** `make test-lib TEST_FILE=test_hug-upstream.bats` + the greps above
+
+**Steps:**
+
+- [ ] **Step 1: Write the stub tests** — append to `tests/lib/test_hug-upstream.bats`:
+
+```bash
+################################################################################
+# #235: pin the load-bearing `|| return 1` guards with function-shadowing stubs
+################################################################################
+# WHY stubs: the guards cannot fail naturally (a resolved upstream always counts), which is
+# exactly why they were untested — deleting them keeps every natural-path test green. Bash
+# redefinition shadows the library function for `run`'s subshell. If a guard is removed,
+# the stub's failure falls through into the preview/message blocks and these tests go red.
+
+@test "#235: count guard pinned — failing count_commits_in_range -> non-zero, no preview" {
+  # Pins the guard at hug-git-upstream:49 (NOT the get_upstream_commit guard at :41).
+  create_test_repo_with_history
+  setup_synced_upstream
+  advance_remote 1
+  count_commits_in_range() { return 1; }
+  run handle_upstream_operation "moving back" "warn" "back" "discards local-only commits"
+  assert_failure
+  refute_output --partial "Commits to be affected"
+}
+
+@test "#235 symmetry: commit_offset guard pinned — failing offset in the ==0 branch -> non-zero" {
+  create_test_repo_with_history
+  setup_synced_upstream                    # count is 0 -> the ==0 branch executes
+  commit_offset() { return 1; }
+  run handle_upstream_operation "moving back" "warn" "back" "discards local-only commits"
+  assert_failure
+  refute_output --partial "Already synced"
+  refute_output --partial "behind upstream"
+}
+```
+
+- [ ] **Step 2: Verify they pass, then prove discrimination** — run the suite (green). Then temporarily delete `|| return 1` from the count line (~:49), re-run → stub test 1 RED; restore the guard, re-run → green. (This proves the test pins the guard; do NOT skip the restore.)
+
+- [ ] **Step 3: Fix the README attribution** — in `git-config/lib/README.md`, replace the line (~:460):
+
+```
+# (callers use `|| exit $?`) -- set -e is suspended inside $(…):
+```
+
+with:
+
+```
+# (callers use `|| exit $?`). WHY the explicit `|| return 1` below is load-bearing, two
+# axes: errexit never fires MID-BODY inside $(…) — only the substitution's FINAL status
+# propagates, via the assignment — and errexit is additionally suspended throughout any
+# function called from a `||` position, which is exactly how every caller invokes this
+# helper. Its internal `|| return 1` guards are therefore the ONLY failure-propagation path:
+```
+
+- [ ] **Step 4: Fix the oxymoron** — in `git-config/lib/hug-git-commit` (:237), replace:
+
+```
+# STRICT-display twin of count_commits_in_range.
+```
+
+with:
+
+```
+# Display-only, failure-tolerant twin of count_commits_in_range.
+```
+
+Leave the surrounding "NEVER use this for a branching or alignment decision" block (:240-244) verbatim.
+
+- [ ] **Step 5: Run + commit** — `make test-lib TEST_FILE=test_hug-upstream.bats` green, then:
+
+```bash
+hug a tests/lib/test_hug-upstream.bats git-config/lib/README.md git-config/lib/hug-git-commit
+```
+Message subject: `test+docs(lib): pin the || return 1 guards; correct set-e attribution; fix oxymoron (#235/#236/#239)`.
+
+---
+
+### Task 6: Perimeter docs — head.md rewrites + CHANGELOG (spec §6/§7)
+
+**Goal:** Bring the user-facing docs into the change-set: head.md's two stale passages about forward recovery, and the CHANGELOG entries (including the duplicate-`[Unreleased]` wart).
+
+**Files:**
+- Modify: `docs/commands/head.md` (~:125, ~:155-165), `CHANGELOG.md` (:5-6, :71)
+
+**Acceptance Criteria:**
+- [ ] head.md:125 no longer claims re-invoking the mover "would short-circuit on the aligned-target check"
+- [ ] head.md's "Why a dedicated recovery command?" rationale states the post-batch truth (backward movers reject descendant targets loudly; restore is the sanctioned forward mover); the two design-decision bullets stay (they remain true)
+- [ ] CHANGELOG top `[Unreleased]` gains the batch's three entries
+- [ ] exactly ONE `## [Unreleased]` header remains; the orphan block's entries are merged under `[1.3.0]`
+
+**Verify:** `grep -c '^## \[Unreleased\]' CHANGELOG.md` → 1 · `grep -q 'short-circuit on the aligned-target check' docs/commands/head.md` fails · `make docs-build` succeeds
+
+**Steps:**
+
+- [ ] **Step 1: Rewrite head.md:125** — in the `hug h restore` Description bullet, replace:
+
+```
+Unlike re-invoking the mover (which would short-circuit on the aligned-target check), `hug h restore` uses exact-SHA equality for its no-op test, allowing it to move HEAD **forward** to a descendant commit.
+```
+
+with:
+
+```
+Unlike re-invoking the mover (backward movers reject a forward target loudly — `hug h back <descendant>` errors and points here), `hug h restore` is the sanctioned forward mover: its no-op test is exact-SHA equality, never a range count, so it can move HEAD **forward** to a descendant commit.
+```
+
+- [ ] **Step 2: Rewrite the rationale paragraph** (~:159, under "Why a dedicated recovery command?") — replace:
+
+```
+Re-invoking a HEAD-mover (e.g., `hug h back abc123`) to recover forward **does not work** -- the mover's aligned-target check (`count_commits_in_range target HEAD == 0`) short-circuits to a no-op whenever the target is a descendant of HEAD. Since the pre-op HEAD is always ahead after a successful backward move, any re-invocation of the mover silently exits 0 without moving HEAD.
+```
+
+with:
+
+```
+Re-invoking a HEAD-mover (e.g., `hug h back abc123`) to recover forward **does not work** — backward movers validate direction: a descendant target is rejected with a loud error ("…is ahead of HEAD… use `hug h restore <target> --<op>`"), because a forward move through a backward-named command is a direction mistake. Since the pre-op HEAD is always ahead after a successful backward move, forward recovery goes through `hug h restore`.
+```
+
+- [ ] **Step 3: CHANGELOG entries** — under the top `## [Unreleased]` (:5), add:
+
+```markdown
+### Fixed
+
+- **`h back`/`h undo`/`h rollback` reject invalid and forward explicit targets loudly** — a garbage target could previously trigger the root-recovery path (undoing the root commit on nonsense input), and a forward target moved HEAD through a backward-named command; both now error, with forward targets pointing at `hug h restore <target> --<op>` (elifarley/hug-scm#234). Root-recovery is now reachable only with no positional target.
+- **`commit_offset`'s Usage docstring corrected to the errexit-safe capture idiom** (`offset=$(…) || rc=$?`) — the previous form (capture, then read the status on the next line) is dead code under `set -e` for exactly the exit codes the dispatch exists to distinguish (discovered while specifying #234's gate).
+
+### Changed
+
+- **`-u` operations report "N commit(s) behind upstream" instead of the false "Already synced" when HEAD is behind upstream** — aligned keeps its message; the exit-0 no-op contract is unchanged (elifarley/hug-scm#237).
+```
+
+- [ ] **Step 4: Merge the orphan block** — the second `## [Unreleased]` (~:71) holds worktree-family entries that shipped before 1.3.0 was cut (verify: `git log --format='%ad' --date=short -1 4b81519` prints a date ≤ 2026-07-15). Delete that `## [Unreleased]` header line so its Fixed/Changed/Added subsections fall under the `## [1.3.0] - 2026-07-15` section above. Confirm `grep -c '^## \[Unreleased\]' CHANGELOG.md` prints 1.
+
+- [ ] **Step 5: Build docs + commit** — `make docs-build` succeeds, then:
+
+```bash
+hug a docs/commands/head.md CHANGELOG.md
+```
+Message subject: `docs: head.md forward-recovery truth + CHANGELOG entries for the correctness batch (#234/#237)`.
+
+---
+
+### Task 7: Final verification gate — sanitize, full suite, canaries, smoke
+
+**Goal:** The full quality gate proving the batch ships green with no leakage or residue.
+
+**Files:** (verification only; if sanitize reformats anything, fold it into the relevant task's commit via `hug cmod --no-edit` after `hug a`)
+
+**Acceptance Criteria:**
+- [ ] `make sanitize` passes
+- [ ] `make test` passes except the two documented pre-existing environmental failures (test_hug-file-input `.env` gitignore; `hug c` git-identity sanitization) — both reproduce identically on `main`
+- [ ] canary: `grep -rn '|| echo 0' git-config/ | wc -l` → 1
+- [ ] no stale names: `grep -rnE 'is_aligned|commits_ahead_behind' git-config/ tests/` → empty
+- [ ] `commit_offset` docstring carries the errexit-safe idiom (already committed in `afb753e` — verify-only): `grep -q 'offset=$(commit_offset "target" HEAD) || rc=$?' git-config/lib/hug-git-commit`
+- [ ] head.md stale phrasing gone: `grep -q 'short-circuit on the aligned-target check' docs/commands/head.md` → non-zero exit
+- [ ] Phase-2 absent: `grep -rnE 'direction_between|report_head_move|HUG_HEAD_MOVE_DIRECTION' git-config/` → empty
+- [ ] smoke: in a scratch repo, `hug h back garbage` at root fails loudly with the root commit intact
+
+**Verify:** the commands above, in order
+
+**Steps:**
+
+- [ ] **Step 1:** `make sanitize` — if it reformats anything, `hug a <files>` and fold into the originating commit (`hug cmod --no-edit` only if it is the tip; otherwise leave staged and note it).
+- [ ] **Step 2:** `make test` — full suite; compare failures against the two documented environmental ones (verify they reproduce on main if in doubt).
+- [ ] **Step 3:** Run the four greps above; each must match its expectation exactly.
+- [ ] **Step 4:** Smoke — `SCRATCH=$(mktemp -d) && git init -q "$SCRATCH" && cd "$SCRATCH" && echo x > f && git add f && git -c user.email=s@s -c user.name=s commit -q -m root`, then run `env HUG_FORCE=true hug h back garbage` → expect non-zero exit and `'garbage' is not a valid commit`; confirm `git rev-parse HEAD` still resolves.
+- [ ] **Step 5:** No commit needed unless Step 1 produced changes. Report the gate results.
+
+---
+
+## Task dependencies
+
+```
+T1 ──> T2 ──> T3 ──┐
+T4 ──> T5          ├──> T6 ──> T7
+       (T5 also ───┘ via T4's guard)
+```
+
+T4 is independent of T1–T3 and may run in parallel with T2/T3.

--- a/docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md
+++ b/docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md
@@ -1,7 +1,7 @@
 # Head-mover correctness batch — design
 
 Date: 2026-08-06
-Status: Approved (brainstorming, design sections §1–§5 validated)
+Status: Approved (brainstorming, design sections §1–§5 validated; spec-roast findings folded 2026-08-06)
 Tracks: elifarley/hug-scm#234, elifarley/hug-scm#237, elifarley/hug-scm#235, elifarley/hug-scm#236, elifarley/hug-scm#239
 Parent context: elifarley/hug-scm#222 (HEAD-mover family audit), elifarley/hug-scm#233 (count_commits_in_range audit, merged)
 
@@ -63,13 +63,44 @@ handlers):
 validate_backward_target <target> <op>
 ```
 
-Contract (built on `commit_offset`, one call resolves all three outcomes):
+Contract — kept deliberately ISOMORPHIC to `commit_offset`'s documented outcome table
+(hug-git-commit), so the two can never drift. All FOUR outcomes must be mapped; the naive
+`offset=$(commit_offset …) || return 1` form conflates exit 2 with exit 3 and is FORBIDDEN
+(the library's own comment warns about exactly this conflation):
 
-| Input | Result |
+| Input (`commit_offset "$target" HEAD`) | Result |
 |---|---|
-| unresolvable target (`commit_offset` exit 3) | `error "'<target>' is not a valid commit"` + non-zero |
-| target AHEAD of HEAD (`offset < 0`) | `error "hug h <op> moves HEAD back, but '<target>' is ahead of HEAD by N commit(s) (use 'hug h restore' to move forward)"` + non-zero |
-| target is HEAD or an ancestor (`offset >= 0`) | silent pass, exit 0 |
+| unresolvable target (exit 3, empty stdout) | `error "'<target>' is not a valid commit"` + non-zero |
+| DIVERGED target (exit 2, empty stdout) | silent pass — a valid SIDEWAYS move; preserves today's behavior (see decision below) |
+| target AHEAD of HEAD (exit 0, offset < 0) | `error "hug h <op> moves HEAD back, but '<target>' is ahead of HEAD by N commit(s) (use 'hug h restore' to move forward)"` + non-zero |
+| target is HEAD or an ancestor (exit 0, offset >= 0) | silent pass, exit 0 |
+
+**Diverged policy — silent pass.** `hug h undo main` is a documented everyday invocation
+(docs/commands/head.md) and, on a branch whose `main` has advanced, `main` is diverged
+from HEAD. Today the movers preview and reset to such a target (a sideways move); this
+batch must not change that (§5 "no behavior change"). Whether sideways moves through
+backward-named commands deserve their own semantics is exactly #230's question
+(sub-project A) — it is NOT decided here.
+
+**Mandated implementation shape** — dispatch on the exit code, never on the offset alone
+(on exit 2 stdout is EMPTY, so any `[ "$offset" … ]` test evaluates the empty string):
+
+```bash
+validate_backward_target() {
+    local target="$1" op="$2" offset rc
+    offset=$(commit_offset "$target" HEAD); rc=$?
+    case $rc in
+      3) error "'$target' is not a valid commit"; return 1 ;;
+      2) return 0 ;;   # diverged: valid sideways move — today's behavior, NOT an error
+      0) ;;
+      *) return 1 ;;   # unreachable; loud by construction
+    esac
+    if [ "$offset" -lt 0 ]; then
+        error "hug h $op moves HEAD back, but '$target' is ahead of HEAD by ${offset#-} commit(s) (use 'hug h restore' to move forward)"
+        return 1
+    fi
+}
+```
 
 **Wiring (identical seam in all three movers):** insert the call right after
 `resolve_target_with_temporal` in the NON-upstream path, before the root-path branch,
@@ -82,9 +113,10 @@ Contract (built on `commit_offset`, one call resolves all three outcomes):
 EXPLICIT targets only. The DEFAULT `HEAD~1` is skipped by design: at the root commit it
 legitimately does not resolve — that unresolved default is precisely the trigger for the
 root-recovery branch, so validating it would break the legitimate no-arg case. Temporal
-(`-t`) targets are out of scope of the gate too (already resolved-and-validated by
-`resolve_temporal_to_commit`; their forward-move behavior is the pre-existing post-#233
-semantics, and a target-by-time is not a "typed the wrong ref" mistake).
+(`-t`) targets are out of scope of the gate too: `resolve_temporal_to_commit` resolves
+exclusively within HEAD's own history (`git log … HEAD --reverse`), so a temporal target
+is ALWAYS an ancestor of HEAD — a valid backward move by construction — and a mistyped
+time spec is not the "typed the wrong ref" mistake this gate exists for.
 
 **Defense in depth:** the root-path guard additionally requires an empty positional arg:
 
@@ -102,6 +134,7 @@ target, so a future refactor of the validator cannot re-open the hole.
 |---|---|---|
 | `h back garbage` | error: not a valid commit | error: not a valid commit |
 | `h back <descendant>` | error: is ahead of HEAD | error: is ahead of HEAD |
+| `h back <diverged-ref>` | impossible (the root commit is an ancestor of every commit, so nothing diverges from it) | silent pass — sideways move, unchanged behavior |
 | `h back <ancestor>` | normal back move | normal back move (unchanged) |
 | `h back` (no arg) | root-recovery, danger tier (unchanged) | default move back 1 (unchanged) |
 
@@ -142,15 +175,26 @@ precisely what `commit_offset` distinguishes.
 ```bash
 if [ "$local_commits" -eq 0 ]; then
     local offset
-    offset=$(commit_offset "$target" HEAD) || return 1   # 0 aligned, -N behind; diverged unreachable
+    offset=$(commit_offset "$target" HEAD) || return 1   # 0 aligned, -N behind; diverged unreachable here (diverged ⇒ ahead > 0)
+    local target_short
+    target_short=$(git rev-parse --short "$target")
     if [ "$offset" -eq 0 ]; then
         info "Already synced to upstream ($target_short)."
         exit 0
     fi
+    local upstream_branch
+    upstream_branch=$(git for-each-ref --format='%(upstream:short)' "$(git symbolic-ref HEAD)" 2>/dev/null || echo "upstream")
     info "Nothing to move: HEAD is ${offset#-} commit(s) behind upstream ($upstream_branch). Pull or rebase to catch up."
     exit 0
 fi
 ```
+
+`set -u` safety: every variable used above is computed INSIDE the branch (declaration and
+assignment on separate lines, per the `local x=$(…)` masking pitfall). The branch label
+uses the same detached-HEAD-safe computation as the preview block further down
+(`git symbolic-ref HEAD` guarded by `2>/dev/null || echo "upstream"`); neither
+`target_short` nor `upstream_branch` exists earlier in `handle_upstream_operation`, so
+they must not be referenced before this computation.
 
 Decisions:
 
@@ -163,13 +207,21 @@ Decisions:
 
 ## §3 Hygiene trio
 
-**#235 — pin `handle_upstream_operation`'s `|| return 1`.** The guard cannot fail
-naturally (if the upstream resolves, the count resolves), which is why it is untested —
-and deleting it currently keeps the suite green. Test design: source the lib, redefine
-`count_commits_in_range() { return 1; }` (bash redefinition shadows the library
+**#235 — pin `handle_upstream_operation`'s `|| return 1` — the count guard at
+hug-git-upstream:49 specifically** (the helper carries a SECOND `|| return 1` at :41 on
+`get_upstream_commit`; the plan must pin the :49 one, not that one). The :49 guard cannot
+fail naturally (if the upstream resolves, the count resolves), which is why it is
+untested — and deleting it currently keeps the suite green. Test design: source the lib,
+redefine `count_commits_in_range() { return 1; }` (bash redefinition shadows the library
 function), call `handle_upstream_operation` in a repo with a valid upstream, assert
 non-zero exit AND no preview output. Without the guard the stub's failure falls through
 into the preview block, so the test goes red — the regression it exists to prevent.
+
+**Symmetry:** §2 adds a NEW `|| return 1` guard (`offset=$(commit_offset …) || return 1`
+inside the `== 0` branch); it must not ship unpinned while its sibling gets pinned. One
+more stub test covers it: redefine `commit_offset() { return 1; }` in a repo whose HEAD
+is synced with upstream (so the `== 0` branch executes), assert `handle_upstream_operation`
+returns non-zero with no message conflated into the synced/behind paths.
 
 **#236 — README set-e attribution** (~git-config/lib/README.md:460): "set -e is suspended
 inside `$(…)`" is wrong — capture does not suspend errexit; the `|| exit $?` call context
@@ -185,18 +237,22 @@ for a branching or alignment decision" guidance verbatim.
 TDD throughout; only `make test-*` targets.
 
 - **#234 helper layer** (`tests/lib/test_hug-upstream.bats`): `validate_backward_target`
-  garbage → "not a valid commit"; forward/descendant → "is ahead of HEAD by N"; ancestor
-  and self → silent pass.
+  garbage → "not a valid commit"; forward/descendant → "is ahead of HEAD by N";
+  DIVERGED → silent pass (exit 0, no message); ancestor and self → silent pass.
 - **#234 mover layer** (`tests/unit/test_head.bats`): full matrix for `h back` at root
   (garbage → loud failure + root commit intact; `<descendant>` → loud failure; no-arg →
   root-recovery proceeds at danger tier; valid ancestor → normal move). Spot-checks of
-  the same three shapes for `h undo` and `h rollback` (identical wiring; per-command
-  matrices would be redundant).
+  the same shapes for `h undo` and `h rollback` (identical wiring; per-command matrices
+  would be redundant), PLUS a sideways spot-check for the documented everyday shape
+  (`hug h undo main` with an advanced `main` → proceeds to preview/reset, unchanged).
 - **#237** (`tests/lib/test_hug-upstream.bats`): aligned → "Already synced"; behind →
   "N commit(s) behind … pull or rebase"; exit 0 in both.
-- **#235**: the function-shadowing stub test above.
-- **Regression guard:** all existing targeted suites stay green (head 157, upstream 10,
-  restore 18, cmv 35, lib-commit 43). Valid backward targets behave identically.
+- **#235**: the two function-shadowing stub tests above.
+- **Regression guard,** stated by concern surface: every suite asserting the changed
+  "Already synced" message stays green — `test_workflows.bats` ×4 (h-back/-undo/-rollback/
+  -squash `-u` synced, integration) and `test_head.bats` ×1 (h-rewind `-u`) — and all
+  existing targeted suites stay green (head 157, upstream 10, restore 18, cmv 35,
+  lib-commit 43, workflows 22). Valid backward targets behave identically.
 - **Canary:** `grep -rn '|| echo 0' git-config/` stays at exactly 1 hit — new comments
   must not reintroduce the literal pipe-form (the #233 born-broken-canary lesson).
 
@@ -214,6 +270,18 @@ Explicitly NOT in this batch:
 - **No behavior change** for valid backward targets or any `-u` path beyond the truthful
   message.
 
+## §6 CHANGELOG entry
+
+`CHANGELOG.md` maintains an empty `## [Unreleased]` section and documents every
+user-visible change in detail (see the 1.4.0 entries). This batch ships two user-visible
+behavior changes and MUST add entries there:
+
+- **Fixed** — loud errors for invalid/forward explicit targets in `h back`/`h undo`/
+  `h rollback` (a garbage target could previously trigger the root-recovery path; a
+  forward target was a silent surprise): elifarley/hug-scm#234.
+- **Changed** — `-u` operations now report "N commit(s) behind upstream" instead of the
+  false "Already synced" when HEAD is behind: elifarley/hug-scm#237.
+
 ## Risks / notes
 
 - `validate_backward_target` adds one rev-parse + one rev-list traversal per explicit
@@ -224,3 +292,9 @@ Explicitly NOT in this batch:
 - #237's behind-message mentions pull/rebase generically; which one is right depends on
   the user's intent. This is informational guidance, not a command suggestion with
   force-semantics, so the generic wording is acceptable (Phase-2 messaging can refine).
+- **Sequencing with sub-project A:** the batch-A Phase-2 spec
+  (`2026-07-30-head-mover-direction-messaging-design.md`) records the `-u` retained
+  no-op (`local_commits == 0` → "Already synced", exit 0) as UNCHANGED context; this
+  batch rewrites exactly that branch's message (semantics preserved: exit 0 in-subshell
+  no-op, helper stdout contract `echo "$target"` intact). Either landing order works,
+  but A's spec text should be refreshed to match if this batch lands first.

--- a/docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md
+++ b/docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md
@@ -72,7 +72,7 @@ Contract — kept deliberately ISOMORPHIC to `commit_offset`'s documented outcom
 |---|---|
 | unresolvable target (exit 3, empty stdout) | `error "'<target>' is not a valid commit"` + non-zero |
 | DIVERGED target (exit 2, empty stdout) | silent pass — a valid SIDEWAYS move; preserves today's behavior (see decision below) |
-| target AHEAD of HEAD (exit 0, offset < 0) | `error "hug h <op> moves HEAD back, but '<target>' is ahead of HEAD by N commit(s) (use 'hug h restore' to move forward)"` + non-zero |
+| target AHEAD of HEAD (exit 0, offset < 0) | `error "hug h <op> moves HEAD back, but '<target>' is ahead of HEAD by N commit(s) (use 'hug h restore <target> --<op>' to move forward)"` + non-zero |
 | target is HEAD or an ancestor (exit 0, offset >= 0) | silent pass, exit 0 |
 
 **Diverged policy — silent pass.** `hug h undo main` is a documented everyday invocation
@@ -102,10 +102,13 @@ validate_backward_target() {
       3) error "'$user_input' is not a valid commit" ;;
       2) return 0 ;;   # diverged: valid sideways move — today's behavior, NOT an error
       0) ;;
-      *) return 1 ;;   # unreachable; loud by construction
+      # unreachable today (commit_offset's exit surface is total over {0,2,3}) — but an
+      # `error`, not a bare return: a bare non-zero return here would surface as a
+      # MESSAGELESS errexit abort, the exact opposite of this batch's loud-failure promise
+      *) error "internal error: commit_offset returned unexpected status $rc for '$user_input'" ;;
     esac
     if [ "$offset" -lt 0 ]; then
-        error "hug h $op moves HEAD back, but '$user_input' is ahead of HEAD by ${offset#-} commit(s) (use 'hug h restore' to move forward)"
+        error "hug h $op moves HEAD back, but '$user_input' is ahead of HEAD by ${offset#-} commit(s) (use 'hug h restore $user_input --$op' to move forward)"
     fi
 }
 ```
@@ -118,7 +121,8 @@ internally-resolved `HEAD~1`.)
 **Docstring sync:** `commit_offset`'s Usage docstring in `hug-git-commit` teaches this
 capture idiom and shipped the broken `; rc=$?` form (this spec's first draft transcribed
 it). This batch fixes that docstring to the `|| rc=$?` form above — spec and library doc
-stay isomorphic, so neither can re-infect the other.
+stay isomorphic, so neither can re-infect the other. (Already applied on this spec
+branch in `afb753e`; verify-only at implementation time — do not re-apply.)
 
 **Test-layer warning:** BATS `run` DISABLES errexit, so helper-layer tests pass green on
 a broken capture idiom (probed). The mover-layer e2e — a real `hug h …` script under
@@ -130,8 +134,11 @@ mover-layer assertion that the diverged shape PROCEEDS rather than exiting silen
 **conditioned on a non-empty positional arg**:
 
 ```bash
-[[ -n "$target_arg" ]] && validate_backward_target "$target" "back" "$target_arg"
+[[ -n "$target_arg" ]] && validate_backward_target "$target" "<op>" "$target_arg"
 ```
+
+(`<op>` is each mover's own name — `"back"` in h-back, `"undo"` in h-undo, `"rollback"`
+in h-rollback — so the error text names the command the user actually ran.)
 
 EXPLICIT targets only. The DEFAULT `HEAD~1` is skipped by design: at the root commit it
 legitimately does not resolve — that unresolved default is precisely the trigger for the
@@ -248,10 +255,15 @@ more stub test covers it: redefine `commit_offset() { return 1; }` in a repo who
 is synced with upstream (so the `== 0` branch executes), assert `handle_upstream_operation`
 returns non-zero with no message conflated into the synced/behind paths.
 
-**#236 — README set-e attribution** (~git-config/lib/README.md:460): "set -e is suspended
-inside `$(…)`" is wrong — capture does not suspend errexit; the `|| exit $?` call context
-does (commands on the left of `||`, and functions called there). Reword to attribute the
-suspension to `|| exit $?` and state that this is why the `|| return 1` is load-bearing.
+**#236 — README set-e attribution** (~git-config/lib/README.md:460): reword to state BOTH
+axes precisely (probed on the project bash 5.1): errexit never fires MID-BODY inside
+`$(…)` — only the substitution's FINAL status propagates, via the assignment — and errexit
+is additionally disabled throughout any function called from a `||` position.
+`handle_upstream_operation` is always captured left of `|| exit $?`, so its internal
+`|| return 1` guards are the ONLY propagation path. (Do NOT transcribe the earlier draft's
+blanket clause "capture does not suspend errexit" — a mid-body `false` inside `$( )` does
+not abort, but a `( )` subshell inherits errexit and does; the axis-specific wording above
+is the one that is true.)
 
 **#239 — oxymoron reword** (git-config/lib/hug-git-commit:237): "STRICT-display twin" →
 "Display-only, failure-tolerant twin of `count_commits_in_range`". Keep the "NEVER use

--- a/docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md
+++ b/docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md
@@ -82,32 +82,55 @@ batch must not change that (§5 "no behavior change"). Whether sideways moves th
 backward-named commands deserve their own semantics is exactly #230's question
 (sub-project A) — it is NOT decided here.
 
-**Mandated implementation shape** — dispatch on the exit code, never on the offset alone
-(on exit 2 stdout is EMPTY, so any `[ "$offset" … ]` test evaluates the empty string):
+**Mandated implementation shape** — two non-negotiable idioms:
+
+1. **Dispatch on the exit code, never on the offset alone** (on exit 2 stdout is EMPTY,
+   so any `[ "$offset" … ]` test evaluates the empty string).
+2. **Capture via `|| rc=$?` — the assignment MUST sit left of `||`.** A bare
+   `offset=$(commit_offset …)` followed by `rc=$?` is DEAD CODE under the movers'
+   `set -euo pipefail`: the assignment statement's exit status IS the substitution's, so
+   errexit aborts the mover at the assignment for exactly exit 2 and exit 3 — the two
+   codes the dispatch exists to distinguish (empirically probed: silent exit, dispatch
+   never reached; the `|| rc=$?` form reaches it). Same failure class as the
+   `local x=$(…)` masking pitfall: a capture that hides the captured command's failure.
 
 ```bash
 validate_backward_target() {
-    local target="$1" op="$2" offset rc
-    offset=$(commit_offset "$target" HEAD); rc=$?
+    local target="$1" op="$2" user_input="${3:-$1}" offset rc=0
+    offset=$(commit_offset "$target" HEAD) || rc=$?
     case $rc in
-      3) error "'$target' is not a valid commit"; return 1 ;;
+      3) error "'$user_input' is not a valid commit" ;;
       2) return 0 ;;   # diverged: valid sideways move — today's behavior, NOT an error
       0) ;;
       *) return 1 ;;   # unreachable; loud by construction
     esac
     if [ "$offset" -lt 0 ]; then
-        error "hug h $op moves HEAD back, but '$target' is ahead of HEAD by ${offset#-} commit(s) (use 'hug h restore' to move forward)"
-        return 1
+        error "hug h $op moves HEAD back, but '$user_input' is ahead of HEAD by ${offset#-} commit(s) (use 'hug h restore' to move forward)"
     fi
 }
 ```
+
+(The `error` arms carry no `return 1` — `error` hard-exits the shell (hug-output), so a
+return after it is unreachable. `user_input` defaults to `$1`; wiring passes the user's
+LITERAL argument so `hug h back 1` at root reports `'1' is not a valid commit`, not the
+internally-resolved `HEAD~1`.)
+
+**Docstring sync:** `commit_offset`'s Usage docstring in `hug-git-commit` teaches this
+capture idiom and shipped the broken `; rc=$?` form (this spec's first draft transcribed
+it). This batch fixes that docstring to the `|| rc=$?` form above — spec and library doc
+stay isomorphic, so neither can re-infect the other.
+
+**Test-layer warning:** BATS `run` DISABLES errexit, so helper-layer tests pass green on
+a broken capture idiom (probed). The mover-layer e2e — a real `hug h …` script under
+`set -euo pipefail` — is the ONLY layer that can catch it; §4 therefore mandates a
+mover-layer assertion that the diverged shape PROCEEDS rather than exiting silently.
 
 **Wiring (identical seam in all three movers):** insert the call right after
 `resolve_target_with_temporal` in the NON-upstream path, before the root-path branch,
 **conditioned on a non-empty positional arg**:
 
 ```bash
-[[ -n "$target_arg" ]] && validate_backward_target "$target" "back"
+[[ -n "$target_arg" ]] && validate_backward_target "$target" "back" "$target_arg"
 ```
 
 EXPLICIT targets only. The DEFAULT `HEAD~1` is skipped by design: at the root commit it
@@ -134,7 +157,8 @@ target, so a future refactor of the validator cannot re-open the hole.
 |---|---|---|
 | `h back garbage` | error: not a valid commit | error: not a valid commit |
 | `h back <descendant>` | error: is ahead of HEAD | error: is ahead of HEAD |
-| `h back <diverged-ref>` | impossible (the root commit is an ancestor of every commit, so nothing diverges from it) | silent pass — sideways move, unchanged behavior |
+| `h back <diverged-ref>` | silent pass — sideways move (reachable: orphan branches and fetched foreign roots DO diverge from the root; only single-root histories cannot) | silent pass — sideways move, unchanged behavior |
+| `h back N` (explicit numeric, e.g. `1`) | error: `'N' is not a valid commit` (`HEAD~N` does not exist at root) — **behavior change**: today this triggers root-recovery, but an explicit target is a user assertion, so loud failure is #234's policy | normal move back N (unchanged) |
 | `h back <ancestor>` | normal back move | normal back move (unchanged) |
 | `h back` (no arg) | root-recovery, danger tier (unchanged) | default move back 1 (unchanged) |
 
@@ -190,11 +214,12 @@ fi
 ```
 
 `set -u` safety: every variable used above is computed INSIDE the branch (declaration and
-assignment on separate lines, per the `local x=$(…)` masking pitfall). The branch label
-uses the same detached-HEAD-safe computation as the preview block further down
-(`git symbolic-ref HEAD` guarded by `2>/dev/null || echo "upstream"`); neither
+assignment on separate lines, per the `local x=$(…)` masking pitfall). Neither
 `target_short` nor `upstream_branch` exists earlier in `handle_upstream_operation`, so
-they must not be referenced before this computation.
+they must not be referenced before this computation. The branch label mirrors the preview
+block's computation (`git symbolic-ref HEAD` guarded by `2>/dev/null || echo "upstream"`)
+for PARITY — the fallback cannot actually fire inside this helper, because
+`get_upstream_commit` already resolved `@{u}`, which requires an attached HEAD.
 
 Decisions:
 
@@ -244,15 +269,21 @@ TDD throughout; only `make test-*` targets.
   root-recovery proceeds at danger tier; valid ancestor → normal move). Spot-checks of
   the same shapes for `h undo` and `h rollback` (identical wiring; per-command matrices
   would be redundant), PLUS a sideways spot-check for the documented everyday shape
-  (`hug h undo main` with an advanced `main` → proceeds to preview/reset, unchanged).
+  (`hug h undo main` with an advanced/diverged `main`) asserting it PROCEEDS to
+  preview/reset — NOT a silent non-zero exit. This assertion is the batch's only defense
+  against the errexit capture bug: `bats run` disables errexit, so a broken
+  `offset=$(…); rc=$?` idiom passes the helper layer green and dies only in the real
+  mover script under `set -euo pipefail`.
 - **#237** (`tests/lib/test_hug-upstream.bats`): aligned → "Already synced"; behind →
   "N commit(s) behind … pull or rebase"; exit 0 in both.
 - **#235**: the two function-shadowing stub tests above.
 - **Regression guard,** stated by concern surface: every suite asserting the changed
   "Already synced" message stays green — `test_workflows.bats` ×4 (h-back/-undo/-rollback/
   -squash `-u` synced, integration) and `test_head.bats` ×1 (h-rewind `-u`) — and all
-  existing targeted suites stay green (head 157, upstream 10, restore 18, cmv 35,
-  lib-commit 43, workflows 22). Valid backward targets behave identically.
+  existing targeted suites stay green. Counts, with measurement bases labeled: head 157,
+  upstream 10, restore 18, lib-commit 43, workflows 22 are whole-file `@test` counts;
+  cmv 35 is the `TEST_FILTER=cmv` topic SUBSET of `test_commit.bats` (72 tests total).
+  Valid backward targets behave identically.
 - **Canary:** `grep -rn '|| echo 0' git-config/` stays at exactly 1 hit — new comments
   must not reintroduce the literal pipe-form (the #233 born-broken-canary lesson).
 
@@ -265,22 +296,47 @@ Explicitly NOT in this batch:
   `docs/superpowers/specs/2026-07-30-head-mover-direction-messaging-design.md`).
 - **#222 concerns 3/4/5** — sub-project C (audit).
 - **#232** (target-aware untracked-overwrite escalation) — separate issue, not batch B.
-- **h-rewind / h-squash** — no root-recovery path; they inherit only the shared-helper
-  §2 message.
+- **h-rewind / h-squash** — no root-recovery path, so §1's gate has no seam there. The
+  §2 truthful message is a different story: it lands on ALL SIX callers of
+  `handle_upstream_operation` (h-back, h-undo, h-rollback, h-rewind, h-squash, h-cmv)
+  via the shared helper.
 - **No behavior change** for valid backward targets or any `-u` path beyond the truthful
   message.
 
 ## §6 CHANGELOG entry
 
-`CHANGELOG.md` maintains an empty `## [Unreleased]` section and documents every
-user-visible change in detail (see the 1.4.0 entries). This batch ships two user-visible
-behavior changes and MUST add entries there:
+`CHANGELOG.md` documents every user-visible change in detail (see the 1.4.0 entries).
+Structural wart to handle while touching it: the file carries TWO `## [Unreleased]`
+headers (:5 empty, :71 populated with already-shipped wtdel entries). The batch's entries
+go in the TOP one; rename the second block to its actual release (pre-existing wart,
+cheap to fix in the same edit). Entries:
 
 - **Fixed** — loud errors for invalid/forward explicit targets in `h back`/`h undo`/
   `h rollback` (a garbage target could previously trigger the root-recovery path; a
   forward target was a silent surprise): elifarley/hug-scm#234.
 - **Changed** — `-u` operations now report "N commit(s) behind upstream" instead of the
   false "Already synced" when HEAD is behind: elifarley/hug-scm#237.
+- **Fixed** — `commit_offset`'s Usage docstring recommended a capture idiom
+  (`offset=$(…); rc=$?`) that aborts `set -e` callers before the dispatch can run;
+  corrected to the `|| rc=$?` form (discovered while specifying #234's gate).
+
+## §7 Perimeter documentation — docs/commands/head.md
+
+`head.md` documents the EXACT fate this batch rewrites, and is already stale:
+
+- `head.md:155-165` ("Why a dedicated recovery command?") claims re-invoking a mover
+  with a forward target "silently exits 0" via the `count_commits_in_range == 0`
+  aligned check. Stale since #229-Phase-1 (the guard is `is_same_commit` and a forward
+  target PROCEEDS, pinned by test_hug-upstream.bats), and doubly wrong post-batch:
+  forward explicit targets error LOUDLY via `validate_backward_target`.
+- `head.md:125` repeats the mechanism parenthetically ("which would short-circuit on
+  the aligned-target check").
+
+Both passages rewrite to the post-batch truth: a backward mover REJECTS a forward
+explicit target with a loud error pointing at `hug h restore`; restore remains the
+sanctioned forward mover, and its actual rationale (exact-SHA no-op test, op-named mode
+flags) is unchanged and stays. Land with this batch; sequence per the note in
+Risks/notes.
 
 ## Risks / notes
 
@@ -297,4 +353,6 @@ behavior changes and MUST add entries there:
   no-op (`local_commits == 0` → "Already synced", exit 0) as UNCHANGED context; this
   batch rewrites exactly that branch's message (semantics preserved: exit 0 in-subshell
   no-op, helper stdout contract `echo "$target"` intact). Either landing order works,
-  but A's spec text should be refreshed to match if this batch lands first.
+  but A's spec text should be refreshed to match if this batch lands first. The head.md
+  perimeter rewrite (§7) lands WITH this batch and supersedes the stale passages for
+  either order.

--- a/docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md
+++ b/docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md
@@ -1,0 +1,226 @@
+# Head-mover correctness batch — design
+
+Date: 2026-08-06
+Status: Approved (brainstorming, design sections §1–§5 validated)
+Tracks: elifarley/hug-scm#234, elifarley/hug-scm#237, elifarley/hug-scm#235, elifarley/hug-scm#236, elifarley/hug-scm#239
+Parent context: elifarley/hug-scm#222 (HEAD-mover family audit), elifarley/hug-scm#233 (count_commits_in_range audit, merged)
+
+## Context
+
+The #222 family audit and the #233 count-range audit left a residue of follow-up issues.
+They decompose into three independent sub-projects; this spec is **batch B, the safety +
+correctness batch**. Batches A (family overhaul: elifarley/hug-scm#240 direction-truthful
+messaging + elifarley/hug-scm#230 `h back` naming) and C (#222 concerns 3/4/5 audit) are
+separate specs.
+
+Of #222's original six concerns, three are already resolved (1+2 by elifarley/hug-scm#231,
+6 by #233). This batch closes the remaining correctness residue.
+
+## Goals
+
+1. **#234** — an explicit garbage or forward target in `h-back`/`h-undo`/`h-rollback`
+   fails LOUDLY instead of silently triggering root-recovery (a destructive operation).
+2. **#237** — the `-u` upstream path stops claiming "Already synced" when HEAD is
+   actually behind upstream.
+3. **#235/#236/#239** — pin the load-bearing `|| return 1` guard with a test; correct two
+   misleading doc wordings.
+
+## Non-goals
+
+See §5 Scope exclusions.
+
+## §1 Backward-target validation (#234)
+
+### Root cause
+
+`git-h-back:96`, `git-h-undo:106`, `git-h-rollback:101` share one shape:
+
+```bash
+if ! git rev-parse --verify --quiet "$target" > /dev/null 2>&1 && is_at_root_commit; then
+    # root-recovery path → reset_root_commit <mode>
+```
+
+Two distinct conditions both satisfy `! rev-parse`:
+
+- the LEGITIMATE one: no explicit target, default `HEAD~1` does not exist because HEAD is
+  at the root commit;
+- a GARBAGE explicit target (`hug h back notaref`), at ANY position, and at root it is
+  indistinguishable from the legitimate case.
+
+`resolve_target_with_temporal` deliberately swallows explicit-target resolution failures
+(its fallback returns the raw ref for `handle_standard_operation` to reject later) — but
+at root the root-recovery branch intercepts FIRST. Result: `hug h back garbage` at the
+root commit performs `reset_root_commit` — the most destructive thing the command can do
+— on nonsense input. Temporal and `-u` targets are already validated; the gap is
+specifically the explicit positional argument.
+
+### The fix
+
+New shared helper in `git-config/lib/hug-git-upstream` (home of the other operation
+handlers):
+
+```
+validate_backward_target <target> <op>
+```
+
+Contract (built on `commit_offset`, one call resolves all three outcomes):
+
+| Input | Result |
+|---|---|
+| unresolvable target (`commit_offset` exit 3) | `error "'<target>' is not a valid commit"` + non-zero |
+| target AHEAD of HEAD (`offset < 0`) | `error "hug h <op> moves HEAD back, but '<target>' is ahead of HEAD by N commit(s) (use 'hug h restore' to move forward)"` + non-zero |
+| target is HEAD or an ancestor (`offset >= 0`) | silent pass, exit 0 |
+
+**Wiring (identical seam in all three movers):** insert the call right after
+`resolve_target_with_temporal` in the NON-upstream path, before the root-path branch,
+**conditioned on a non-empty positional arg**:
+
+```bash
+[[ -n "$target_arg" ]] && validate_backward_target "$target" "back"
+```
+
+EXPLICIT targets only. The DEFAULT `HEAD~1` is skipped by design: at the root commit it
+legitimately does not resolve — that unresolved default is precisely the trigger for the
+root-recovery branch, so validating it would break the legitimate no-arg case. Temporal
+(`-t`) targets are out of scope of the gate too (already resolved-and-validated by
+`resolve_temporal_to_commit`; their forward-move behavior is the pre-existing post-#233
+semantics, and a target-by-time is not a "typed the wrong ref" mistake).
+
+**Defense in depth:** the root-path guard additionally requires an empty positional arg:
+
+```bash
+if [[ -z "$target_arg" ]] && ! git rev-parse --verify --quiet "$target" … && is_at_root_commit; then
+```
+
+The validator already rejects unresolvable EXPLICIT targets before this line; the
+`-z target_arg` clause makes root-recovery structurally unreachable for any explicit
+target, so a future refactor of the validator cannot re-open the hole.
+
+### Behavior matrix
+
+| Input | at root | not at root |
+|---|---|---|
+| `h back garbage` | error: not a valid commit | error: not a valid commit |
+| `h back <descendant>` | error: is ahead of HEAD | error: is ahead of HEAD |
+| `h back <ancestor>` | normal back move | normal back move (unchanged) |
+| `h back` (no arg) | root-recovery, danger tier (unchanged) | default move back 1 (unchanged) |
+
+Note the forward-explicit case becomes a loud error EVEN NOT-AT-ROOT. This is deliberate
+and strictly safer than the post-#233 status quo (which silently allowed forward moves
+through a backward-named command); restore is the sanctioned forward mover.
+
+### Decisions
+
+- **`-u` path is EXEMPT.** Syncing to upstream legitimately discards local-only commits;
+  "forward relative to HEAD" is the point of `-u`, not an error.
+- **Error exit code: plain `error` + exit 1.** No new code invented — exit-code taxonomy
+  is #222 concern 4's job (batch C).
+- **Danger tier of root-recovery is preserved** (per #233's §6 rationale: recovery at
+  root is a guaranteed loud failure, so no complete recovery licenses a warn tier).
+
+## §2 Truthful sync-state messaging (#237)
+
+### Defect
+
+`handle_upstream_operation` (hug-git-upstream:51-54):
+
+```bash
+if [ "$local_commits" -eq 0 ]; then
+    info "Already synced to upstream (…)"; exit 0
+```
+
+`count_commits_in_range(target, HEAD) == 0` means "HEAD is not AHEAD of upstream" — also
+true when HEAD is BEHIND. This is the exact `count==0 ⟹ aligned` conflation #233 killed
+in the guards, surviving in a display message.
+
+Key property: **diverged cannot reach this branch** (diverged ⇒ ahead > 0 ⇒ the preview
+path). The `== 0` branch contains exactly two states — aligned or behind — which is
+precisely what `commit_offset` distinguishes.
+
+### Fix (inside the existing `== 0` branch)
+
+```bash
+if [ "$local_commits" -eq 0 ]; then
+    local offset
+    offset=$(commit_offset "$target" HEAD) || return 1   # 0 aligned, -N behind; diverged unreachable
+    if [ "$offset" -eq 0 ]; then
+        info "Already synced to upstream ($target_short)."
+        exit 0
+    fi
+    info "Nothing to move: HEAD is ${offset#-} commit(s) behind upstream ($upstream_branch). Pull or rebase to catch up."
+    exit 0
+fi
+```
+
+Decisions:
+
+- **Behind is informational + exit 0**, not a warning/non-zero: "you asked to move local
+  commits upstream and there are none" is still a successful no-op — the message just has
+  to be honest.
+- **Lives in the shared helper**, so all six `-u` callers get it at once.
+- **Bonus:** first PRODUCTION caller of `commit_offset`, advancing #238 (its eventual
+  full home is Phase-2 direction messaging).
+
+## §3 Hygiene trio
+
+**#235 — pin `handle_upstream_operation`'s `|| return 1`.** The guard cannot fail
+naturally (if the upstream resolves, the count resolves), which is why it is untested —
+and deleting it currently keeps the suite green. Test design: source the lib, redefine
+`count_commits_in_range() { return 1; }` (bash redefinition shadows the library
+function), call `handle_upstream_operation` in a repo with a valid upstream, assert
+non-zero exit AND no preview output. Without the guard the stub's failure falls through
+into the preview block, so the test goes red — the regression it exists to prevent.
+
+**#236 — README set-e attribution** (~git-config/lib/README.md:460): "set -e is suspended
+inside `$(…)`" is wrong — capture does not suspend errexit; the `|| exit $?` call context
+does (commands on the left of `||`, and functions called there). Reword to attribute the
+suspension to `|| exit $?` and state that this is why the `|| return 1` is load-bearing.
+
+**#239 — oxymoron reword** (git-config/lib/hug-git-commit:237): "STRICT-display twin" →
+"Display-only, failure-tolerant twin of `count_commits_in_range`". Keep the "NEVER use
+for a branching or alignment decision" guidance verbatim.
+
+## §4 Testing strategy
+
+TDD throughout; only `make test-*` targets.
+
+- **#234 helper layer** (`tests/lib/test_hug-upstream.bats`): `validate_backward_target`
+  garbage → "not a valid commit"; forward/descendant → "is ahead of HEAD by N"; ancestor
+  and self → silent pass.
+- **#234 mover layer** (`tests/unit/test_head.bats`): full matrix for `h back` at root
+  (garbage → loud failure + root commit intact; `<descendant>` → loud failure; no-arg →
+  root-recovery proceeds at danger tier; valid ancestor → normal move). Spot-checks of
+  the same three shapes for `h undo` and `h rollback` (identical wiring; per-command
+  matrices would be redundant).
+- **#237** (`tests/lib/test_hug-upstream.bats`): aligned → "Already synced"; behind →
+  "N commit(s) behind … pull or rebase"; exit 0 in both.
+- **#235**: the function-shadowing stub test above.
+- **Regression guard:** all existing targeted suites stay green (head 157, upstream 10,
+  restore 18, cmv 35, lib-commit 43). Valid backward targets behave identically.
+- **Canary:** `grep -rn '|| echo 0' git-config/` stays at exactly 1 hit — new comments
+  must not reintroduce the literal pipe-form (the #233 born-broken-canary lesson).
+
+## §5 Scope exclusions
+
+Explicitly NOT in this batch:
+
+- **#240 / #230 / the "changes in 0 commit:" forward-preview cosmetic** — sub-project A
+  (family overhaul; Phase-2 spec exists:
+  `docs/superpowers/specs/2026-07-30-head-mover-direction-messaging-design.md`).
+- **#222 concerns 3/4/5** — sub-project C (audit).
+- **#232** (target-aware untracked-overwrite escalation) — separate issue, not batch B.
+- **h-rewind / h-squash** — no root-recovery path; they inherit only the shared-helper
+  §2 message.
+- **No behavior change** for valid backward targets or any `-u` path beyond the truthful
+  message.
+
+## Risks / notes
+
+- `validate_backward_target` adds one rev-parse + one rev-list traversal per explicit
+  target; negligible for an interactive safety gate.
+- The `-z target_arg` guard clause relies on `target_arg` being in scope at the root-path
+  check — true in all three movers today (parsed in the flag loop before the branch); the
+  implementation plan must keep it that way.
+- #237's behind-message mentions pull/rebase generically; which one is right depends on
+  the user's intent. This is informational guidance, not a command suggestion with
+  force-semantics, so the generic wording is acceptable (Phase-2 messaging can refine).

--- a/git-config/bin/git-h-back
+++ b/git-config/bin/git-h-back
@@ -92,8 +92,17 @@ else
   # Use DRY helper for validation and target resolution
   target=$(resolve_target_with_temporal "$upstream" "$temporal_spec" "$target_arg" 'HEAD~1') || exit 1
 
-  # Handle root commit scenario (target doesn't exist because we're at the first commit)
-  if ! git rev-parse --verify --quiet "$target" > /dev/null 2>&1 && is_at_root_commit; then
+  # #234: an EXPLICIT target must be a valid BACKWARD move — garbage fails loudly (never a
+  # root-recovery on nonsense input) and a forward target points at restore instead of moving
+  # HEAD through a backward-named command. The default HEAD~1 is skipped by design: at root it
+  # legitimately does not resolve — that unresolved default IS the root-recovery trigger below.
+  [[ -n "$target_arg" ]] && validate_backward_target "$target" "back" "$target_arg"
+
+  # Handle root commit scenario (target doesn't exist because we're at the first commit).
+  # Defense in depth (#234): the `[[ -z "$target_arg" ]]` clause makes root-recovery
+  # STRUCTURALLY unreachable for any explicit target, even if validate_backward_target is
+  # later refactored — only the default HEAD~1 (no positional) may land here.
+  if [[ -z "$target_arg" ]] && ! git rev-parse --verify --quiet "$target" > /dev/null 2>&1 && is_at_root_commit; then
     # Show preview of the root commit
     if [[ ${HUG_QUIET:-} != T ]]; then
       printf 'Commits to be affected:\n' >&2

--- a/git-config/bin/git-h-rollback
+++ b/git-config/bin/git-h-rollback
@@ -97,8 +97,17 @@ else
   # Use DRY helper for validation and target resolution
   target=$(resolve_target_with_temporal "$upstream" "$temporal_spec" "$target_arg" 'HEAD~1') || exit 1
 
-  # Handle root commit scenario (target doesn't exist because we're at the first commit)
-  if ! git rev-parse --verify --quiet "$target" > /dev/null 2>&1 && is_at_root_commit; then
+  # #234: an EXPLICIT target must be a valid BACKWARD move — garbage fails loudly (never a
+  # root-recovery on nonsense input) and a forward target points at restore instead of moving
+  # HEAD through a backward-named command. The default HEAD~1 is skipped by design: at root it
+  # legitimately does not resolve — that unresolved default IS the root-recovery trigger below.
+  [[ -n "$target_arg" ]] && validate_backward_target "$target" "rollback" "$target_arg"
+
+  # Handle root commit scenario (target doesn't exist because we're at the first commit).
+  # Defense in depth (#234): the `[[ -z "$target_arg" ]]` clause makes root-recovery
+  # STRUCTURALLY unreachable for any explicit target, even if validate_backward_target is
+  # later refactored — only the default HEAD~1 (no positional) may land here.
+  if [[ -z "$target_arg" ]] && ! git rev-parse --verify --quiet "$target" > /dev/null 2>&1 && is_at_root_commit; then
     # Show what will be deleted (tracked files only)
     tracked_count=$(git ls-files | wc -l | tr -d ' ')
 

--- a/git-config/bin/git-h-undo
+++ b/git-config/bin/git-h-undo
@@ -102,8 +102,17 @@ else
   # Use DRY helper for validation and target resolution
   target=$(resolve_target_with_temporal "$upstream" "$temporal_spec" "$target_arg" 'HEAD~1') || exit 1
 
-  # Handle root commit scenario (target doesn't exist because we're at the first commit)
-  if ! git rev-parse --verify --quiet "$target" > /dev/null 2>&1 && is_at_root_commit; then
+  # #234: an EXPLICIT target must be a valid BACKWARD move — garbage fails loudly (never a
+  # root-recovery on nonsense input) and a forward target points at restore instead of moving
+  # HEAD through a backward-named command. The default HEAD~1 is skipped by design: at root it
+  # legitimately does not resolve — that unresolved default IS the root-recovery trigger below.
+  [[ -n "$target_arg" ]] && validate_backward_target "$target" "undo" "$target_arg"
+
+  # Handle root commit scenario (target doesn't exist because we're at the first commit).
+  # Defense in depth (#234): the `[[ -z "$target_arg" ]]` clause makes root-recovery
+  # STRUCTURALLY unreachable for any explicit target, even if validate_backward_target is
+  # later refactored — only the default HEAD~1 (no positional) may land here.
+  if [[ -z "$target_arg" ]] && ! git rev-parse --verify --quiet "$target" > /dev/null 2>&1 && is_at_root_commit; then
     # Show preview of the root commit
     if [[ ${HUG_QUIET:-} != T ]]; then
       printf 'Commits to be affected:\n' >&2

--- a/git-config/lib/README.md
+++ b/git-config/lib/README.md
@@ -458,7 +458,11 @@ print_commit_list_in_range "origin/main" "HEAD"
 # The tier parameter (warn|danger) controls which prompt function is used.
 # Prints the upstream commit SHA to stdout. Its internal ahead-count is STRICT
 # (count_commits_in_range) and carries `|| return 1`, so capture it with a guard
-# (callers use `|| exit $?`) -- set -e is suspended inside $(…):
+# (callers use `|| exit $?`). WHY the explicit `|| return 1` below is load-bearing, two
+# axes: errexit never fires MID-BODY inside $(…) — only the substitution's FINAL status
+# propagates, via the assignment — and errexit is additionally suspended throughout any
+# function called from a `||` position, which is exactly how every caller invokes this
+# helper. Its internal `|| return 1` guards are therefore the ONLY failure-propagation path:
 target=$(handle_upstream_operation "rewinding" "warn" "rewind" "danger reason") || exit $?
 
 # For standard operations (back, undo, etc.)

--- a/git-config/lib/hug-git-commit
+++ b/git-config/lib/hug-git-commit
@@ -267,8 +267,13 @@ is_same_commit() {
 
 # Signed commit distance from <a> to <b> (default HEAD). 0 means IDENTITY (same commit),
 # NOT merely "not ahead" — the false-zero is unrepresentable by construction.
-# Usage: dispatch on $? — exit 2 (diverged) and exit 3 (error) need DISTINCT handling:
-#   offset=$(commit_offset "target" HEAD); rc=$?
+# Usage: dispatch on $? — exit 2 (diverged) and exit 3 (error) need DISTINCT handling.
+# Capture via `|| rc=$?` — the assignment MUST sit left of `||`: a bare
+# `offset=$(commit_offset …)` followed by `rc=$?` is DEAD CODE under `set -e`, because
+# the assignment statement's exit status IS the substitution's, so errexit aborts the
+# caller at the assignment for exactly exit 2 and 3 — before any dispatch can run.
+#   local offset rc=0
+#   offset=$(commit_offset "target" HEAD) || rc=$?
 #   case $rc in
 #     0) use "$offset" ;;   # identity (0) or a clean signed distance (N / -N)
 #     2) handle_diverged ;; # incomparable histories — NOT an error, NOT a distance

--- a/git-config/lib/hug-git-upstream
+++ b/git-config/lib/hug-git-upstream
@@ -49,7 +49,22 @@ handle_upstream_operation() {
     local_commits=$(count_commits_in_range "$target" HEAD) || return 1
 
     if [ "$local_commits" -eq 0 ]; then
-        info "Already synced to upstream ($(git rev-parse --short "$target"))."
+        # == 0 means "not AHEAD": aligned OR behind (diverged is unreachable here —
+        # diverged ⇒ ahead > 0). commit_offset distinguishes exactly these two states;
+        # this is its first production caller (#238).
+        local offset
+        offset=$(commit_offset "$target" HEAD) || return 1
+        local target_short
+        target_short=$(git rev-parse --short "$target")
+        if [ "$offset" -eq 0 ]; then
+            info "Already synced to upstream ($target_short)."
+            exit 0
+        fi
+        local upstream_branch
+        # Parity with the preview block's computation; the fallback cannot actually fire
+        # here (get_upstream_commit already resolved @{u}, which requires an attached HEAD).
+        upstream_branch=$(git for-each-ref --format='%(upstream:short)' "$(git symbolic-ref HEAD)" 2>/dev/null || echo "upstream")
+        info "Nothing to move: HEAD is ${offset#-} commit(s) behind upstream ($upstream_branch). Pull or rebase to catch up."
         exit 0
     fi
 

--- a/git-config/lib/hug-git-upstream
+++ b/git-config/lib/hug-git-upstream
@@ -156,6 +156,44 @@ handle_standard_operation() {
     fi
 }
 
+# Validates an EXPLICIT target for a backward HEAD-mover (h-back / h-undo / h-rollback).
+# Usage: validate_backward_target <target> <op> [<user_input>]
+# Parameters:
+#   $1 - resolved target (may be the raw ref if resolution failed upstream)
+#   $2 - mover name for messages: "back" | "undo" | "rollback"
+#   $3 - (Optional) the user's LITERAL input, quoted in error messages (defaults to $1)
+#
+# Contract — keep ISOMORPHIC to commit_offset's outcome table (hug-git-commit):
+#   unresolvable (exit 3)   -> error "'<input>' is not a valid commit", non-zero
+#   diverged     (exit 2)   -> silent pass — a valid SIDEWAYS move; today's behavior, NOT an error
+#   ahead        (offset<0) -> error "…is ahead of HEAD by N commit(s)…", non-zero
+#   self/ancestor (offset>=0)-> silent pass
+#
+# WHY this gate exists (#234): pre-fix, an unresolvable explicit target at the root commit
+# was indistinguishable from the legitimate "no parent of root" case, so `hug h back garbage`
+# triggered reset_root_commit — the most destructive path — on nonsense input. Callers ALSO
+# tighten their root-path guard to `[[ -z "$target_arg" ]]` (defense in depth).
+validate_backward_target() {
+    local target="$1" op="${2:?validate_backward_target: op required}" user_input="${3:-$1}"
+    local offset rc=0
+    # Capture via `|| rc=$?` — the assignment MUST sit left of `||`: a bare
+    # `offset=$(commit_offset …)` aborts a `set -e` caller at the assignment for exit 2/3,
+    # before the dispatch below can run (same failure class as the local-x-capture masking).
+    offset=$(commit_offset "$target" HEAD) || rc=$?
+    case $rc in
+      3) error "'$user_input' is not a valid commit" ;;
+      2) return 0 ;;   # diverged: valid sideways move — today's behavior, NOT an error
+      0) ;;
+      # unreachable today (commit_offset's exit surface is total over {0,2,3}) — but an
+      # `error`, not a bare return: a bare non-zero return would surface as a MESSAGELESS
+      # errexit abort, the opposite of this batch's loud-failure promise.
+      *) error "internal error: commit_offset returned unexpected status $rc for '$user_input'" ;;
+    esac
+    if [ "$offset" -lt 0 ]; then
+        error "hug h $op moves HEAD back, but '$user_input' is ahead of HEAD by ${offset#-} commit(s) (use 'hug h restore $user_input --$op' to move forward)"
+    fi
+}
+
 ################################################################################
 # Root Commit Operations
 ################################################################################

--- a/git-config/lib/hug-git-upstream
+++ b/git-config/lib/hug-git-upstream
@@ -196,7 +196,14 @@ validate_backward_target() {
     # before the dispatch below can run (same failure class as the local-x-capture masking).
     offset=$(commit_offset "$target" HEAD) || rc=$?
     case $rc in
-      3) error "'$user_input' is not a valid commit" ;;
+      3) # commit_offset returns 3 when EITHER arg is unresolvable. Disambiguate: if the
+      # TARGET itself resolves, the failure is HEAD's (e.g. unborn HEAD — the post-root-undo
+      # recovery state), not the target's. The natural recovery is hug h restore <target>.
+      if git rev-parse --verify --quiet "$target^{commit}" >/dev/null 2>&1; then
+        error "cannot resolve HEAD (unborn?) — use 'hug h restore $user_input --$op' to recover"
+      else
+        error "'$user_input' is not a valid commit"
+      fi ;;
       2) return 0 ;;   # diverged: valid sideways move — today's behavior, NOT an error
       0) ;;
       # unreachable today (commit_offset's exit surface is total over {0,2,3}) — but an

--- a/tests/lib/test_hug-upstream.bats
+++ b/tests/lib/test_hug-upstream.bats
@@ -165,6 +165,20 @@ teardown() {
   assert_output --partial "'definitely-not-a-ref' is not a valid commit"
 }
 
+@test "validate_backward_target: valid target + UNBORN HEAD -> 'cannot resolve HEAD' (not a target error) + restore hint" {
+  # When HEAD is unborn (the post-root-undo recovery state), commit_offset(target, HEAD)
+  # returns 3 because its SECOND arg fails — NOT because the target is invalid. The exit-3
+  # arm must disambiguate: a valid target means HEAD is the problem, and the natural recovery
+  # is `hug h restore <target> --<op>`. Pre-fix this mislabeled a valid SHA as "not a valid commit".
+  local saved; saved=$(git rev-parse HEAD)
+  git update-ref -d HEAD                           # -> unborn HEAD
+  run validate_backward_target "$saved" "back"
+  assert_failure
+  assert_output --partial "cannot resolve HEAD"
+  assert_output --partial "hug h restore $saved --back"
+  refute_output --partial "'$saved' is not a valid commit"
+}
+
 @test "validate_backward_target: forward (descendant) target -> 'ahead of HEAD' + pasteable restore hint" {
   local descendant; descendant=$(git rev-parse HEAD)
   git update-ref HEAD HEAD~1                  # plumbing: HEAD back one, descendant now ahead

--- a/tests/lib/test_hug-upstream.bats
+++ b/tests/lib/test_hug-upstream.bats
@@ -250,3 +250,32 @@ advance_remote() {
   assert_output --partial "Pull or rebase to catch up"
   refute_output --partial "Already synced"
 }
+
+################################################################################
+# #235: pin the load-bearing `|| return 1` guards with function-shadowing stubs
+################################################################################
+# WHY stubs: the guards cannot fail naturally (a resolved upstream always counts), which is
+# exactly why they were untested — deleting them keeps every natural-path test green. Bash
+# redefinition shadows the library function for `run`'s subshell. If a guard is removed,
+# the stub's failure falls through into the preview/message blocks and these tests go red.
+
+@test "#235: count guard pinned — failing count_commits_in_range -> non-zero, no preview" {
+  # Pins the guard at hug-git-upstream:49 (NOT the get_upstream_commit guard at :41).
+  create_test_repo_with_history
+  setup_synced_upstream
+  advance_remote 1
+  count_commits_in_range() { return 1; }
+  run handle_upstream_operation "moving back" "warn" "back" "discards local-only commits"
+  assert_failure
+  refute_output --partial "Commits to be affected"
+}
+
+@test "#235 symmetry: commit_offset guard pinned — failing offset in the ==0 branch -> non-zero" {
+  create_test_repo_with_history
+  setup_synced_upstream                    # count is 0 -> the ==0 branch executes
+  commit_offset() { return 1; }
+  run handle_upstream_operation "moving back" "warn" "back" "discards local-only commits"
+  assert_failure
+  refute_output --partial "Already synced"
+  refute_output --partial "behind upstream"
+}

--- a/tests/lib/test_hug-upstream.bats
+++ b/tests/lib/test_hug-upstream.bats
@@ -193,3 +193,60 @@ teardown() {
   assert_success
   [ -z "$output" ]
 }
+
+################################################################################
+# handle_upstream_operation: truthful aligned-vs-behind messaging (#237)
+################################################################################
+# count(target..HEAD) == 0 means "not AHEAD" — also true when HEAD is BEHIND upstream.
+# Diverged cannot reach the branch (diverged ⇒ ahead > 0), so it is a clean 2-state split.
+
+# Shared fixture: repo + bare origin + push + attached upstream (HEAD synced with origin).
+setup_synced_upstream() {
+  local branch; branch=$(git branch --show-current)
+  REMOTE_REPO=$(mktemp -d -p "${BATS_TEST_TMPDIR}" -t "up-synced-origin-XXXXXX")/origin.git
+  git init --bare -q "$REMOTE_REPO"
+  git remote add origin "$REMOTE_REPO"
+  git push -q origin "$branch"
+  git branch --set-upstream-to="origin/$branch" >&2
+}
+
+# Advances origin by N empty commits (via a clone), leaving HEAD BEHIND upstream.
+# Fetches afterward so the LOCAL refs/remotes/origin/<branch> tracking ref updates —
+# @{u} resolves against the local ref, not the remote, so without the fetch the upstream
+# would still appear "aligned" with a stale SHA.
+# Pushes explicitly to refs/heads/<branch> — a fresh clone of a bare repo with mismatched
+# default branches (origin's HEAD vs. the test branch) lands on the WRONG branch otherwise,
+# advancing a sibling ref and leaving the tracked one untouched.
+advance_remote() {
+  local n="$1" clone_dir branch
+  branch=$(git branch --show-current)
+  clone_dir=$(mktemp -d -p "${BATS_TEST_TMPDIR}" -t "up-advance-clone-XXXXXX")/clone
+  git clone -q -b "$branch" "$REMOTE_REPO" "$clone_dir"
+  local i=1
+  while [ "$i" -le "$n" ]; do
+    git -C "$clone_dir" -c user.email=test@test -c user.name=test \
+        commit -q --allow-empty -m "remote advance $i"
+    i=$((i + 1))
+  done
+  git -C "$clone_dir" push -q origin "HEAD:refs/heads/$branch"
+  git fetch -q origin
+}
+
+@test "handle_upstream_operation: aligned -> 'Already synced' (unchanged), exit 0 (#237)" {
+  create_test_repo_with_history
+  setup_synced_upstream
+  run handle_upstream_operation "moving back" "warn" "back" "discards local-only commits"
+  assert_success
+  assert_output --partial "Already synced to upstream"
+}
+
+@test "handle_upstream_operation: HEAD BEHIND upstream -> truthful behind message, exit 0 (#237)" {
+  create_test_repo_with_history
+  setup_synced_upstream
+  advance_remote 2
+  run handle_upstream_operation "moving back" "warn" "back" "discards local-only commits"
+  assert_success
+  assert_output --partial "Nothing to move: HEAD is 2 commit(s) behind upstream"
+  assert_output --partial "Pull or rebase to catch up"
+  refute_output --partial "Already synced"
+}

--- a/tests/lib/test_hug-upstream.bats
+++ b/tests/lib/test_hug-upstream.bats
@@ -150,3 +150,46 @@ teardown() {
   run handle_upstream_operation "moving" warn "move" "reason"
   assert_failure
 }
+
+################################################################################
+# validate_backward_target: #234 — explicit targets must be valid BACKWARD moves
+################################################################################
+# NOTE on test layers: bats `run` DISABLES errexit, so these helper-layer tests would
+# pass green even on a capture idiom broken under set -e. The mover-layer e2e tests in
+# tests/unit/test_head.bats (real scripts under set -euo pipefail) are the layer that
+# catches that — do not delete them in favor of these.
+
+@test "validate_backward_target: garbage target -> 'not a valid commit', non-zero" {
+  run validate_backward_target "definitely-not-a-ref" "back"
+  assert_failure
+  assert_output --partial "'definitely-not-a-ref' is not a valid commit"
+}
+
+@test "validate_backward_target: forward (descendant) target -> 'ahead of HEAD' + pasteable restore hint" {
+  local descendant; descendant=$(git rev-parse HEAD)
+  git update-ref HEAD HEAD~1                  # plumbing: HEAD back one, descendant now ahead
+  run validate_backward_target "$descendant" "back"
+  assert_failure
+  assert_output --partial "is ahead of HEAD by 1 commit(s)"
+  assert_output --partial "hug h restore $descendant --back"
+}
+
+@test "validate_backward_target: diverged target -> silent pass (sideways move preserved)" {
+  git checkout -q -b diverger                 # branch at HEAD
+  echo "d" > diverger.txt; git add diverger.txt; git commit -q -m "branch diverges"
+  git checkout -q -                           # back to the original branch
+  echo "l" > local-only.txt; git add local-only.txt; git commit -q -m "HEAD diverges"
+  run validate_backward_target "diverger" "undo"
+  assert_success
+  [ -z "$output" ]                            # contract: diverged is silent — no info/warning either
+}
+
+@test "validate_backward_target: ancestor and self -> silent pass" {
+  run validate_backward_target "HEAD~1" "back"
+  assert_success
+  [ -z "$output" ]
+  local self; self=$(git rev-parse HEAD)
+  run validate_backward_target "$self" "back"
+  assert_success
+  [ -z "$output" ]
+}

--- a/tests/unit/test_head.bats
+++ b/tests/unit/test_head.bats
@@ -2332,3 +2332,36 @@ EOF
   assert_success
   [ "$(git rev-parse HEAD)" = "$target" ]                 # sideways move, NOT a silent exit
 }
+
+@test "hug h undo <garbage> at root: loud failure (#234 spot-check)" {
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+  run env HUG_FORCE=true hug h undo nope-ref
+  assert_failure
+  assert_output --partial "'nope-ref' is not a valid commit"
+}
+
+@test "hug h rollback <garbage> at root: loud failure (#234 spot-check)" {
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+  run env HUG_FORCE=true hug h rollback nope-ref
+  assert_failure
+  assert_output --partial "'nope-ref' is not a valid commit"
+}
+
+@test "hug h undo <diverged-branch>: proceeds (the documented 'hug h undo main' shape) (#234)" {
+  # docs/commands/head.md ships `hug h undo main` as an everyday example; on a branch whose
+  # main has advanced, the target is DIVERGED. The batch must preserve today's sideways
+  # preview/reset — a silent non-zero exit here would regress the everyday shape.
+  create_test_repo_with_history
+  git checkout -q -b advanced-main
+  echo "adv" > advanced.txt; git add advanced.txt; git commit -q -m "main advances"
+  git checkout -q -
+  echo "loc" > local-advance.txt; git add local-advance.txt; git commit -q -m "HEAD advances"
+  local target; target=$(git rev-parse advanced-main)
+
+  run env HUG_FORCE=true hug h undo advanced-main
+
+  assert_success
+  [ "$(git rev-parse HEAD)" = "$target" ]
+}

--- a/tests/unit/test_head.bats
+++ b/tests/unit/test_head.bats
@@ -2196,19 +2196,23 @@ EOF
 # `git rev-parse --short <garbage>`, `git rev-parse HEAD` on unborn HEAD), so these stay green by
 # design. Read them as "the command fails loudly," not "this specific line propagates."
 
-@test "hug h back <descendant>: moves HEAD FORWARD instead of no-op'ing (#229 headline)" {
-  # Defect-1, end-to-end. Build A/B/C (the fixture), record the tip C as the forward target,
-  # then move HEAD back to A so C is a true DESCENDANT of HEAD. Pre-fix this printed
-  # "Already at target" and left HEAD at A; post-fix the mover must walk HEAD forward to C.
+@test "hug h back <descendant>: rejected loudly, points at restore (#234 narrows the #229 headline)" {
+  # Evolution: #229 made forward targets PROCEED through the movers; the #234 batch narrows
+  # that — a FORWARD explicit target through a backward-NAMED mover is a direction mistake,
+  # rejected loudly and pointing at restore (the sanctioned forward mover, which encodes the
+  # reset mode explicitly). A silent forward move through a command named "back" surprised
+  # users; restore is unambiguous.
   local descendant
   descendant=$(git rev-parse HEAD)   # capture the tip BEFORE moving — the forward target (C)
   git reset -q --hard HEAD~2         # HEAD -> A (root); tree clean, descendant is ahead of HEAD
 
   run env HUG_FORCE=true hug h back "$descendant"
 
-  assert_success
-  refute_output --partial "Already at target"          # the no-op guard must NOT fire for a forward target
-  [ "$(git rev-parse HEAD)" = "$descendant" ]          # HEAD actually moved FORWARD to the descendant
+  assert_failure
+  assert_output --partial "is ahead of HEAD by 2 commit(s)"
+  assert_output --partial "hug h restore"
+  refute_output --partial "Already at target"
+  [ "$(git rev-parse HEAD)" != "$descendant" ]   # HEAD did NOT move
 }
 
 @test "hug h squash <invalid-ref>: rejected loudly (garbage ref) (#229)" {
@@ -2248,11 +2252,11 @@ EOF
   # false-NEGATIVE (never a false positive), so the mover falls through to the strict count and
   # fails loudly.
   #
-  # LESSON / why the input is NOT `h back 1` at a valid root: that input takes git-h-back's
-  # dedicated reset_root_commit branch and SUCCEEDS ("root commit undone", HEAD unborn) — already
-  # pinned above by "hug h back: undoes root commit, files stay staged". A naive
-  # `h back 1 at valid root -> assert_failure` is therefore WRONG; the genuine loud-failure state
-  # is the UNBORN HEAD reproduced here via `git update-ref -d HEAD` (what reset_root_commit runs).
+  # LESSON / `h back 1` at a VALID root: since the #234 batch an explicit target is validated
+  # FIRST — `h back 1` (HEAD~1, unresolvable at root) fails loudly with "'1' is not a valid
+  # commit" (pinned below). The root-recovery branch is now reachable ONLY with no positional
+  # target (the `-z target_arg` structural guard), and the no-arg form stays pinned by
+  # "hug h back: undoes root commit, files stay staged".
   local root_sha
   root_sha=$(git rev-list --max-parents=0 HEAD)        # resolve while HEAD is still born
   git update-ref -d HEAD                               # -> unborn HEAD: the post-root-undo recovery state
@@ -2261,4 +2265,70 @@ EOF
 
   assert_failure
   refute_output --partial "Already at target"          # must fail loudly, not no-op silently
+}
+
+# ============================================================================
+# #234 enforcement: explicit targets are validated — garbage/forward fail loudly,
+# sideways (diverged) proceeds, root-recovery is no-arg-only
+# ============================================================================
+
+@test "hug h back <garbage> at root: loud failure, root commit intact (#234)" {
+  # THE reason this batch exists: pre-fix, a garbage explicit target at root was
+  # indistinguishable from "no parent of root" and triggered reset_root_commit.
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+  local root_sha; root_sha=$(git rev-parse HEAD)
+
+  run env HUG_FORCE=true hug h back definitely-not-a-ref
+
+  assert_failure
+  assert_output --partial "'definitely-not-a-ref' is not a valid commit"
+  [ "$(git rev-parse HEAD)" = "$root_sha" ]   # the destructive path never ran
+}
+
+@test "hug h back 1 at root: loud failure quoting the user's literal (#234 behavior change)" {
+  # HEAD~1 does not exist at root. Pre-fix this triggered root-recovery; an explicit target
+  # is a user assertion, so it now fails loudly — quoting what the user TYPED ('1'), not the
+  # internally-resolved HEAD~1 (the validator receives the literal input).
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+
+  run env HUG_FORCE=true hug h back 1
+
+  assert_failure
+  assert_output --partial "'1' is not a valid commit"
+}
+
+@test "hug h back <diverged-orphan-ref> at root: silent pass, sideways move preserved (#234)" {
+  # Orphan branches DO diverge from the root (no common ancestor) — the "diverged at root"
+  # shape is reachable. Policy: silent pass; today's sideways preview/reset, unchanged.
+  local test_repo; test_repo=$(create_test_repo)
+  cd "$test_repo"
+  local other_root; other_root=$(git rev-parse HEAD)
+  git checkout -q --orphan sideway
+  echo "s" > sideways.txt; git add sideways.txt; git commit -q -m "orphan root"
+
+  run env HUG_FORCE=true hug h back "$other_root"
+
+  assert_success
+  [ "$(git rev-parse HEAD)" = "$other_root" ]   # sideways reset happened
+}
+
+@test "hug h back <diverged-branch>: proceeds (THE errexit-detection assertion) (#234)" {
+  # CRITICAL layer: this runs the REAL mover under set -euo pipefail. A broken capture idiom
+  # (offset=$(commit_offset …); rc=$?) dies silently at the assignment for exit 2; bats `run`
+  # at the HELPER layer cannot catch that (run disables errexit). This assertion — diverged
+  # target PROCEEDS instead of exiting silently — is the batch's only defense against a
+  # regression of the capture idiom.
+  create_test_repo_with_history
+  git checkout -q -b advanced-branch
+  echo "adv" > advanced.txt; git add advanced.txt; git commit -q -m "branch advances"
+  git checkout -q -
+  echo "loc" > local-advance.txt; git add local-advance.txt; git commit -q -m "HEAD advances"
+  local target; target=$(git rev-parse advanced-branch)   # diverged from HEAD
+
+  run env HUG_FORCE=true hug h back advanced-branch
+
+  assert_success
+  [ "$(git rev-parse HEAD)" = "$target" ]                 # sideways move, NOT a silent exit
 }


### PR DESCRIPTION
✅ Make the backward HEAD-movers (`h back`/`h undo`/`h rollback`) reject invalid and forward explicit targets loudly, and make `-u` operations report "behind upstream" truthfully (elifarley/hug-scm#234, elifarley/hug-scm#237). Pre-batch, a garbage target at the root commit was indistinguishable from the legitimate "no parent of root" case, so `hug h back garbage` silently undid the root commit; and `hug h <mover> -u` printed "Already synced" even when HEAD was behind upstream.

🟢 Low risk: a shared `validate_backward_target` helper (commit_offset-based, four-outcome dispatch) gates all three movers; root-recovery is now no-arg-only (structural guard); `-u` messaging is the only caller-visible change there. 263 targeted tests green.

More context: https://github.com/elifarley/hug-scm/issues/234

## The validator (`validate_backward_target`, #234)

```bash
[[ -n "$target_arg" ]] && validate_backward_target "$target" "<op>" "$target_arg"
```

| Input | Result |
|---|---|
| unresolvable target (`commit_offset` exit 3) | `error "'<input>' is not a valid commit"` + non-zero (disambiguates unborn HEAD after `a647471`: points at `restore` if the target itself resolves) |
| diverged target (exit 2, e.g. `h undo main` with advanced main) | silent pass — a valid sideways move, today's behavior |
| target ahead of HEAD (exit 0, offset < 0) | `error "…is ahead of HEAD by N commit(s)… use 'hug h restore <target> --<op>'"` + non-zero |
| target is HEAD or an ancestor (offset >= 0) | silent pass |

Two non-negotiable idioms (learned the hard way, see the design spec's roast history): dispatch on the exit code, never on the offset alone (exit 2 has empty stdout); and capture via `local rc=0; offset=$(commit_offset …) || rc=$?` — a bare `offset=$(…); rc=$?` is dead code under `set -e` at exit 2/3.

The `-u` upstream path is **exempt** (syncing legitimately discards local-only commits). Root-recovery danger tier is **preserved** (per #233's §6 rationale). Errors use plain exit 1; no new exit-code taxonomy.

## Honest sync-state messaging (#237)

`handle_upstream_operation`'s `== 0` branch conflated "aligned" with "not ahead" (the same `count==0 ⟹ aligned` idiom #233 killed in the guards). It now splits via `commit_offset` (its first production caller, advancing elifarley/hug-scm#238): aligned keeps the unchanged "Already synced to upstream (<short>)." text; behind prints "Nothing to move: HEAD is N commit(s) behind upstream (<branch>). Pull or rebase to catch up." Both still exit 0 (the in-subshell no-op contract every caller depends on is preserved). All six `-u` callers inherit the truthful message via the shared helper.

<details><summary>Why this scope (and not "just rename" or "leave it")</summary>

Two objections this PR invites, answered up front.

**"The suite is green and the happy path works — what bug?"**

True, and worth conceding: the full suite was green before this PR, and a normal `hug h back 3` never hit the defect. The defect is narrow — it fires only for an **explicit target that fails to resolve while HEAD is at the root commit**. But that narrow shape is proven, not asserted: the test `hug h back <garbage> at root: loud failure, root commit intact (#234)` fails RED on the pre-batch behavior (the root commit gets undone, `git rev-parse HEAD` afterward resolves to nothing) and goes GREEN on the patched tree. So the defect is real and reachable; what is **probable, not proven** is that anyone hit it in production — it requires typing a bad ref at the root commit, and recovery from an unborn HEAD is possible via reflog. The PR's claim is "the destructive path is reachable on nonsense input," which the RED test proves, not "this lost someone's work," which would need an incident report.

The #237 fix is the same shape: the "Already synced" message was **wrong** when HEAD was behind upstream (proven by the new `behind upstream` test, which RED-asserts the old behavior), and **misleading** in a way that could prompt a wrong action. It's a truthfulness fix; whether the old message ever caused a real mistake is probable, not proven.

**"Forward moves worked — why reject them instead of renaming the command?"**

This is the real scope question, and the answer is: **the rename is an open investigation (elifarley/hug-scm#230), not a settled decision, and this PR's choice is the reversible default while it stays open.**

- The reject is **policy behind a validator** (one line per mover). If #230 lands on a rename (`h to`/`h move`/etc.), removing the validator is clean. A rename done first, before the naming question is settled, would be a breaking change to undo if the family later stays backward-only.
- Keeping forward moves on a command named `back` makes the name a lie — and silent-name-lies are the exact failure class this whole audit (#229 → #233 → here) has been killing. A user types `back`, the command goes forward, and the only signal is post-hoc output.
- The sanctioned forward mover, `hug h restore`, already exists (#231) and was purpose-built for direction-agnostic moves (exact-SHA no-op test, op-named mode flag). Redirecting forward targets to it routes them to the primitive designed for them — it is not a workaround.
- "Forward via back" has existed only since #233 (before that, forward targets silently no-op'd). It's a six-month-old behavior, not a load-bearing habit.

There's a known rough edge in the redirect: the suggested `hug h restore <target> --back` carries a flag whose name says "backward" while the user is trying to move forward. That flag naming is itself a symptom of the same vocabulary debt #230 tracks; the decoupling (rename `restore`'s flags to preservation names, `--back`→`--staged`) is proposed on elifarley/hug-scm#230 and is the right place to resolve it, not this PR.

So: this PR is the **truthfulness half** of the still-open #222/#230 family work. It makes the backward movers' contract match their name and makes the `-u` message honest, while leaving the naming question (#230) and the direction-messaging question (#240) to their own specs. Nothing here forecloses either outcome.

</details>

## Hygiene (#235 / #236 / #239)

- **#235** — the two load-bearing `|| return 1` guards in `handle_upstream_operation` (the count guard at `:49`, and the new `commit_offset` guard from #237) are pinned with function-shadowing stub tests. Discrimination proven: removing a guard makes its stub test red.
- **#236** — the README's "set -e is suspended inside `$(…)`" was wrong; reworded to the two-axis truth (mid-body `$(…)` never fires errexit; a function called from a `||` position runs errexit-disabled), which is why those guards are the only failure-propagation path.
- **#239** — fixed the "STRICT-display twin" oxymoron in `count_commits_in_range_or_zero`'s docstring (it is deliberately NOT strict).
- The `commit_offset` Usage docstring was also corrected to the errexit-safe capture idiom (it had shipped the broken `; rc=$?` form during #233).
- `a647471` (review fix): `validate_backward_target`'s exit-3 arm now distinguishes an unborn HEAD (the post-root-undo recovery state) from a genuinely invalid target — a valid SHA no longer misreports as "not a valid commit."

<details><summary>Spec, plan, and decisions</summary>

- Design spec (3 roast rounds, 0 CRITICAL/MAJOR on the final pass): `docs/superpowers/specs/2026-08-06-head-mover-correctness-batch-design.md`
- Implementation plan (7 TDD tasks): `docs/superpowers/plans/2026-08-06-head-mover-correctness-batch.md`

## Tests

263 targeted: `validate_backward_target` (garbage/forward/diverged/ancestor/self, plus unborn-HEAD disambiguation), mover-level matrix for `h back` at root (garbage → root intact; numeric → literal quoted; orphan → sideways proceeds; diverged → proceeds — the batch's only errexit-capture-idiom defense, since `bats run` disables errexit), sibling spot-checks for `h undo`/`h rollback` + the documented `h undo <diverged>` everyday shape, aligned/behind messaging, and the two guard-pin stub tests. The `|| echo 0` canary stays at exactly 1 hit; phase-2 helpers (`direction_between`/`report_head_move`/`HUG_HEAD_MOVE_DIRECTION`) are absent.

Full suite: the only failure is the documented pre-existing environmental one (git-identity sanitization in `hug c`), reproduced identically on `main`.

## CHANGELOG

Three entries under `[Unreleased]` (Fixed: #234 target validation; Fixed: commit_offset docstring idiom; Changed: #237 behind-upstream messaging). Also fixed a pre-existing wart: the file had two `## [Unreleased]` headers; the orphan block's shipped wtdel entries were merged under `[1.3.0]`.

</details>

Closes elifarley/hug-scm#234, elifarley/hug-scm#235, elifarley/hug-scm#236, elifarley/hug-scm#237, elifarley/hug-scm#239. Partially addresses elifarley/hug-scm#238 (commit_offset gains its first production caller). Forward-reject scope and the `--back` flag-naming rough edge are deferred to elifarley/hug-scm#230.
