### PR TITLE
refactor(sl*): run_count_mode wrapper + check_git_repo parity (#258 #259)

### DIFF
--- a/docs/superpowers/plans/2026-08-08-sl-count-engine-refactor.md
+++ b/docs/superpowers/plans/2026-08-08-sl-count-engine-refactor.md
@@ -1,0 +1,553 @@
+# sl* -c Count Engine Refactor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Factor the duplicated `-c/--count` dispatch block across the 6 `sl*` dispatchers into one `run_count_mode` helper (#258), and add `check_git_repo` parity to `count_files_with_status` (#259) — so the count primitive emits the clean HUG "Not in a git repository" message instead of a silent wrong answer.
+
+**Architecture:** Two stacked edits to `git-config/lib/hug-select-files`, in forced order (#259 then #258 — the wrapper delegates to the primitive, so the primitive must carry the invariant first), then wire the 6 `sl*` dispatchers to the new wrapper. The `check_git_repo` dependency is *declared* in `hug-select-files`'s `Depends on:` header (not auto-sourced — `hug-common` is symlinked into `hg-config`, so `hug-select-files` already loads in Mercurial contexts; auto-sourcing the git-specific `hug-git-repo` there would be a VCS-boundary violation). All 6 dispatchers source `hug-git-kit`, which loads `hug-git-repo`, so `check_git_repo` is available to every real caller.
+
+**Tech Stack:** Bash (BATS tests, `set -euo pipefail`), GNU make, shellcheck. Bash floor 4.0 (no `local -n` nameref on the count path).
+
+**Spec:** `docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md` (roast-clean after 3 rounds).
+**Issues:** [elifarley/hug-scm#258](https://github.com/elifarley/hug-scm/issues/258), [elifarley/hug-scm#259](https://github.com/elifarley/hug-scm/issues/259). Out-of-scope arg-parsing hardening tracked as [elifarley/hug-scm#260](https://github.com/elifarley/hug-scm/issues/260).
+
+**Worktree:** `/home/ecc/src/hug-scm.WT.refactor-sl-count-engine-258-259` (branch `refactor-sl-count-engine-258-259`). Do ALL work here; the Bash tool resets CWD between calls, so use absolute paths or `cd` at the start of each command.
+
+**Commit discipline:** Use `hug` commands, never raw git. Commit messages document WHY (load the `commit-message` skill). Because the commit body may reference git internals, use the `GIT-BLOCK:BYPASS` escape hatch in a trailing comment (see `.wolf/cerebrum.md` / the `block-commands.py` hook). One logical commit per task.
+
+---
+
+## File Structure
+
+| File | Responsibility | Touched by |
+|---|---|---|
+| `git-config/lib/hug-select-files` | The `count_files_with_status` primitive + the new `run_count_mode` wrapper. Header `Depends on:` + function list. | Task 1, Task 2 |
+| `tests/lib/test_hug-select-files.bats` | Library tests for the primitive (non-repo error) and the wrapper. | Task 1, Task 2 |
+| `git-config/lib/README.md` | Library reference doc — the doc-perimeter. Add `run_count_mode` entry; amend `count_files_with_status` contract. | Task 1, Task 2 |
+| `git-config/bin/git-sls`, `git-slu`, `git-slk`, `git-sli`, `git-slc` | 5 single-state dispatchers — replace the 13-line count block with one `run_count_mode` call. | Task 3 |
+| `git-config/bin/git-statusbase` | The `all`/`all+untracked` dispatcher — replace its count block (keeps the `include_untracked` if/else). | Task 3 |
+
+`sl`/`sla` delegate to `git-statusbase` via `.gitconfig` aliases, so they are covered transitively (no own copy).
+
+---
+
+### Task 1: #259 — `check_git_repo` parity for `count_files_with_status`
+
+**Goal:** Make `count_files_with_status` emit the clean HUG "Not in a git repository" message (and exit 1) when called outside a repo, instead of a silent wrong answer (`0`, exit 0) — matching the `list_*_files` contract — and declare the new `hug-git-repo` dependency.
+
+**Files:**
+- Modify: `git-config/lib/hug-select-files` (header line 5 `Depends on:`, header line 9 function list, and the first line of `count_files_with_status()` at line 27)
+- Modify: `git-config/lib/README.md` (the `count_files_with_status` entry at line 202)
+- Test: `tests/lib/test_hug-select-files.bats` (insert a new test after the existing `count_files_with_status` tests, ~line 876)
+
+**Acceptance Criteria:**
+- [ ] `count_files_with_status` calls `check_git_repo` as its first executable line.
+- [ ] `hug-select-files`'s `Depends on:` header (line 5) declares `hug-git-repo`.
+- [ ] From a non-repo dir (`mktemp -d`), `count_files_with_status staged` exits 1 with stdout empty and stderr containing "Not in a git repository" (new lib test, `run --separate-stderr`).
+- [ ] All existing in-repo `count_files_with_status` lib tests stay green (they `cd "$repo"` first, so `check_git_repo` passes).
+- [ ] `git-config/lib/README.md` `count_files_with_status` entry notes the repo precondition.
+
+**Verify:** `make test-lib TEST_FILE=test_hug-select-files.bats TEST_SHOW_ALL_RESULTS=1` → all tests pass, including the new non-repo test and the existing count tests.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test.**
+
+In `tests/lib/test_hug-select-files.bats`, insert this test immediately after the existing `count_files_with_status: all+untracked expands untracked dir to its files` test (find it with `grep -n "all+untracked expands" tests/lib/test_hug-select-files.bats`; the test ends at its closing `}`):
+
+```bash
+@test "count_files_with_status: clean error outside a git repo (parity with list_*_files)" {
+  local nonrepo
+  nonrepo=$(mktemp -d)   # fresh, guaranteed non-repo (setup() cds into a repo; leave it)
+  cd "$nonrepo"
+  run --separate-stderr count_files_with_status staged
+  assert_failure
+  [[ -z "$output" ]]                                  # stdout clean: no leaked count (the old silent-0)
+  [[ "$stderr" == *"Not in a git repository"* ]]      # stderr carries the clean HUG message
+  rm -rf "$nonrepo"
+}
+```
+
+This test uses `run --separate-stderr` (BATS ≥1.6; the repo already uses it at `tests/unit/test_status_staging.bats:1947`). `error`→`gum_log` writes `>&2`, so the message lands on `$stderr` and `$output` (stdout) stays clean. `check_git_repo` and `error` are in scope via the test file's existing `load` lines (`hug-common` at line 5 → `hug-output` for `error`; `hug-git-kit` at line 6 → `hug-git-repo` for `check_git_repo`).
+
+- [ ] **Step 2: Run the test to verify it fails.**
+
+Run: `make test-lib TEST_FILE=test_hug-select-files.bats TEST_FILTER="clean error outside a git repo" TEST_SHOW_ALL_RESULTS=1`
+Expected: FAIL. Current behavior (no `check_git_repo`): from a non-repo, every `git` call is suffixed `2>/dev/null`, so `count_files_with_status staged` returns `0` with exit 0 and empty stderr → `assert_failure` fails (and `[[ -z "$output" ]]` fails because `$output` is `0`). This is the silent-wrong-answer bug #259 fixes.
+
+- [ ] **Step 3: Implement — add `check_git_repo` + declare the dependency.**
+
+Edit `git-config/lib/hug-select-files`:
+
+(a) Header `Depends on:` (line 5) — append `hug-git-repo`:
+
+Replace:
+```
+# Depends on: hug-gum, hug-output, hug-terminal, hug-git-files (for list_* functions), hug-git-priorities.
+```
+With:
+```
+# Depends on: hug-gum, hug-output, hug-terminal, hug-git-files (for list_* functions), hug-git-priorities, hug-git-repo (for check_git_repo, used by count_files_with_status).
+```
+
+(b) Header function-list (line 9) — note the repo precondition:
+
+Replace:
+```
+#   - count_files_with_status: count files by state (NUL-safe, scriptable; the sl* `-c` engine).
+```
+With:
+```
+#   - count_files_with_status: count files by state (NUL-safe, scriptable; the sl* `-c` engine; enforces the repo precondition via check_git_repo).
+```
+
+(c) The function body — add `check_git_repo` as the first executable line. The function currently starts (line 27):
+```bash
+count_files_with_status() {
+  local state="$1"
+  shift
+```
+Change to:
+```bash
+count_files_with_status() {
+  check_git_repo   # Parity with list_*_files: clean HUG error from any context (#259)
+  local state="$1"
+  shift
+```
+(Insert the `check_git_repo` line before `local state="$1"`. Do not touch the rest of the function — the counting loop, the `2>/dev/null` suffixes, and the `error "unknown state"` branch stay as-is.)
+
+- [ ] **Step 4: Amend the library README.**
+
+In `git-config/lib/README.md`, the `count_files_with_status` entry (line 202) is:
+```
+- `count_files_with_status <state> [pathspec...]` - Count files by state (the sl* `-c` engine)
+  - `<state>`: `staged`|`unstaged`|`untracked`|`ignored`|`conflicted`|`all`|`all+untracked`
+  - Prints an integer (0 when none, exit 0). NUL-safe (newline filenames count once) and Bash 4.0-safe (no nameref).
+  - `all`/`all+untracked` dedup via `git status --porcelain -z` (a file staged AND unstaged counts once)
+```
+Append a new bullet after the last (`all`/`all+untracked`...) line:
+```
+  - Enforces the repo precondition internally (`check_git_repo`): exits 1 with "Not in a git repository" when called outside a repo (parity with `list_*_files`)
+```
+
+- [ ] **Step 5: Run the test to verify it passes — and the existing count tests stay green.**
+
+Run: `make test-lib TEST_FILE=test_hug-select-files.bats TEST_SHOW_ALL_RESULTS=1`
+Expected: PASS — the new non-repo test passes (`assert_failure`, empty stdout, message on stderr), and all existing `count_files_with_status` tests (per-state counts, dedup, pathspec scoping, NUL-safety, rename, untracked-dir expansion) stay green because they `cd "$repo"` first so `check_git_repo` passes.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+cd /home/ecc/src/hug-scm.WT.refactor-sl-count-engine-258-259
+hug a git-config/lib/hug-select-files git-config/lib/README.md tests/lib/test_hug-select-files.bats
+hug c -F - <<'EOF' # GIT-BLOCK:BYPASS
+fix(sl*): count_files_with_status now checks the repo (parity with list_*_files) (#259)
+
+WHY: count_files_with_status (the sl* -c engine) did not call check_git_repo, unlike
+every list_*_files function. From a non-repo dir this produced a SILENT WRONG ANSWER
+(0, exit 0) — every git call is suffixed 2>/dev/null, so git's error never surfaced. A
+direct library caller had no idea it was not in a repo. #259 fixes this for parity with
+list_*_files, which emits the clean HUG "Not in a git repository" message.
+
+WHAT: Added check_git_repo as the first executable line of count_files_with_status. It
+fails fast with the clean message before spending a subprocess on a doomed count; in a
+repo it is a no-op pass (one git rev-parse --git-dir). Declared the new hug-git-repo
+dependency in hug-select-files's Depends on: header (all 6 sl* dispatchers source
+hug-git-kit, which loads hug-git-repo, so check_git_repo is available to every real
+caller; declared rather than auto-sourced because hug-common is symlinked into
+hg-config, so hug-select-files already loads in Mercurial contexts — auto-sourcing the
+git-specific hug-git-repo there would be a VCS-boundary violation). Updated the in-file
+function-list header and git-config/lib/README.md to note the repo precondition.
+
+HOW: TDD — wrote the non-repo test first (run --separate-stderr; asserts assert_failure +
+empty stdout + "Not in a git repository" on stderr), confirmed it failed against the old
+silent-0 behavior, then added check_git_repo. The existing count_files_with_status lib
+tests (they cd "$repo" first) pin the in-repo contract and stay green unchanged.
+
+IMPACT: count_files_with_status is now safe to call from any context that sources its
+declared deps — outside a repo it fails loudly with the HUG message instead of silently
+returning 0. The check_git_repo call adds one git rev-parse to the count path, negligible
+beside the git subprocesses the function already runs.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 2: #258 — Add the `run_count_mode` wrapper
+
+**Goal:** Add the terminating `run_count_mode [--json] <state> [pathspec...]` helper to `hug-select-files` that encapsulates the `-c` dispatch (mutual-exclusion guard + `count_files_with_status` call + `exit 0`), with focused lib tests, so the 6 `sl*` dispatchers can each collapse their 13-line count block to a one-line call in Task 3.
+
+**Files:**
+- Modify: `git-config/lib/hug-select-files` (add the `run_count_mode` function directly above `count_files_with_status`; add it to the function-list header)
+- Modify: `git-config/lib/README.md` (add a `run_count_mode` entry next to `count_files_with_status`)
+- Test: `tests/lib/test_hug-select-files.bats` (add `run_count_mode` tests next to the `count_files_with_status` tests)
+
+**Acceptance Criteria:**
+- [ ] `run_count_mode [--json] <state> [pathspec...]` exists in `hug-select-files`, directly above `count_files_with_status`.
+- [ ] It is TERMINATING: `error`→exit 1 on the `--json`+`-c` mutex violation, `exit 0` after printing the count; it never returns.
+- [ ] `run_count_mode` lists in the `hug-select-files` function-list header comment.
+- [ ] `git-config/lib/README.md` has a `run_count_mode` entry.
+- [ ] Lib tests: `run_count_mode staged` in a repo with 1 staged file prints `1` and exits 0; `run_count_mode --json staged` exits nonzero with "mutually exclusive" on stderr.
+- [ ] `make sanitize` (shellcheck) passes for `hug-select-files`.
+
+**Verify:** `make test-lib TEST_FILE=test_hug-select-files.bats TEST_FILTER="run_count_mode" TEST_SHOW_ALL_RESULTS=1` → new tests pass; then `make sanitize` → shellcheck clean.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests.**
+
+In `tests/lib/test_hug-select-files.bats`, insert these two tests immediately after the non-repo test added in Task 1 (or next to the other `count_files_with_status` tests):
+
+```bash
+@test "run_count_mode: prints the count and exits 0 (terminating wrapper)" {
+  local repo
+  repo=$(create_test_repo)
+  cd "$repo"
+  echo "staged" > staged.txt
+  git add staged.txt
+
+  # TERMINATING: run in a subshell via `run`; prints the count, exit 0.
+  run --separate-stderr run_count_mode staged
+  assert_success
+  assert_output "1"
+  [[ -z "$stderr" ]]
+}
+
+@test "run_count_mode: --json and -c are mutually exclusive" {
+  local repo
+  repo=$(create_test_repo)
+  cd "$repo"
+  echo "staged" > staged.txt
+  git add staged.txt
+
+  run --separate-stderr run_count_mode --json staged
+  assert_failure
+  [[ "$stderr" == *"mutually exclusive"* ]]
+  [[ -z "$output" ]]   # no count printed on the mutex-violation path
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail.**
+
+Run: `make test-lib TEST_FILE=test_hug-select-files.bats TEST_FILTER="run_count_mode" TEST_SHOW_ALL_RESULTS=1`
+Expected: FAIL — `run_count_mode: command not found` (the function does not exist yet).
+
+- [ ] **Step 3: Implement `run_count_mode`.**
+
+In `git-config/lib/hug-select-files`, insert this function **directly above** the `count_files_with_status()` definition (i.e. immediately before the `count_files_with_status() {` line, after the existing `count_files_with_status` header comment block that ends at `# Prints a single integer (newline-terminated) to stdout; 0 when none; exit 0.` / the blank line before the function):
+
+```bash
+# run_count_mode — terminating wrapper for the sl* -c/--count dispatch.
+# Usage: run_count_mode [--json] <state> [pathspec...]
+#   <state>: the count_files_with_status enum (staged|unstaged|untracked|ignored|
+#           conflicted|all|all+untracked).
+# Encapsulates the -c dispatch previously duplicated (near-verbatim) across the 6 sl*
+# scripts (git-sls/slu/slk/sli/slc/statusbase):
+#   (1) --json is mutually exclusive with -c -> error + exit (like hug wtl's
+#       --json --path-only error),
+#   (2) delegate to count_files_with_status (which itself enforces the repo
+#       precondition -- #259),
+#   (3) exit 0.
+# TERMINATING: calls `exit 0` (and `error`->exit 1 on the --json violation), so it
+#   NEVER returns -- a caller running it inside `if $count_only; then ...; fi` never
+#   reaches code below the block. Callers pass `--json` only when their json flag is
+#   true, e.g. `if $json_output; then run_count_mode --json <state> ...; else
+#   run_count_mode <state> ...; fi`. Do NOT use ${json_output:+--json}: hug stores
+#   booleans as the strings true/false, so :+ fires on the non-empty "false" too and
+#   would ALWAYS pass --json. Do NOT capture this in $(...) : the subshell exit is
+#   contained and the count is captured correctly, but the caller does NOT terminate
+#   -- in the dispatchers, execution falls through to the listing/summary code and
+#   prints BOTH the (captured) count AND the listing (broken output). Call it as a
+#   statement, never as a substitution.
+run_count_mode() {
+  local json=false
+  [[ "${1:-}" == --json ]] && { json=true; shift; }
+  local state="$1"; shift
+  local -a pathspecs=("$@")
+  if $json; then
+    error "-c/--count and --json are mutually exclusive"
+  fi
+  count_files_with_status "$state" "${pathspecs[@]}"
+  exit 0
+}
+```
+
+`local` is legal here (this is a real function body, unlike dispatcher top-level code). `local -a pathspecs=("$@")` declares the array, so `"${pathspecs[@]}"` is safe under `set -u` even when empty — matching the existing `count_files_with_status` pattern.
+
+- [ ] **Step 4: Add `run_count_mode` to the function-list header.**
+
+In `git-config/lib/hug-select-files`, the function-list header (after Task 1) reads:
+```
+#   - count_files_with_status: count files by state (NUL-safe, scriptable; the sl* `-c` engine; enforces the repo precondition via check_git_repo).
+```
+Insert a new line directly after it:
+```
+#   - run_count_mode: terminating wrapper for the sl* -c/--count dispatch (mutual-exclusion guard + count + exit 0).
+```
+
+- [ ] **Step 5: Add the `run_count_mode` README entry.**
+
+In `git-config/lib/README.md`, directly after the `count_files_with_status` entry's last bullet (the "Enforces the repo precondition..." bullet added in Task 1), add:
+```
+- `run_count_mode [--json] <state> [pathspec...]` - Terminating wrapper for the sl* `-c/--count` dispatch
+  - Encapsulates the mutual-exclusion guard + `count_files_with_status` call + `exit 0` (formerly duplicated across the 6 `sl*` dispatchers)
+  - `--json` is mutually exclusive with `-c` (errors and exits); the function ALWAYS exits (never returns) — call it as a statement, never in `$(...)`
+```
+
+- [ ] **Step 6: Run the tests to verify they pass.**
+
+Run: `make test-lib TEST_FILE=test_hug-select-files.bats TEST_FILTER="run_count_mode" TEST_SHOW_ALL_RESULTS=1`
+Expected: PASS — both new tests pass. Then run the full lib file to confirm no regression:
+Run: `make test-lib TEST_FILE=test_hug-select-files.bats TEST_SHOW_ALL_RESULTS=1`
+Expected: all tests pass (the existing count tests + the Task 1 non-repo test + the two new wrapper tests).
+
+- [ ] **Step 7: Run shellcheck.**
+
+Run: `make sanitize`
+Expected: clean (no new shellcheck warnings for `hug-select-files` — `local` inside `run_count_mode()` is valid; the `[[ ... ]] && { ...; }` pattern is safe under `set -euo pipefail`).
+
+- [ ] **Step 8: Commit.**
+
+```bash
+cd /home/ecc/src/hug-scm.WT.refactor-sl-count-engine-258-259
+hug a git-config/lib/hug-select-files git-config/lib/README.md tests/lib/test_hug-select-files.bats
+hug c -F - <<'EOF' # GIT-BLOCK:BYPASS
+refactor(sl*): add run_count_mode wrapper to hug-select-files (#258)
+
+WHY: The -c/--count dispatch block (mutual-exclusion guard + count_files_with_status
+call + exit 0, ~13 lines) plus its ~7-line WHY comment were duplicated near-verbatim
+across the 6 sl* dispatchers (git-sls/slu/slk/sli/slc/statusbase); only the state
+argument differed (and statusbase's all/all+untracked branch). A DRY smell: any future
+change to -c semantics would have to be edited in 6 places.
+
+WHAT: Added run_count_mode [--json] <state> [pathspec...] to hug-select-files, directly
+above count_files_with_status. It owns (1) the --json mutual-exclusion error, (2) the
+delegation to count_files_with_status (which now enforces the repo precondition --
+#259), and (3) exit 0. It is TERMINATING (always exits, never returns): error->exit 1
+on the --json violation, exit 0 after printing the count. The dispatchers (Task 3) will
+each call it via the two-branch `if $json_output; then run_count_mode --json <state> ...;
+else run_count_mode <state> ...; fi` inside `if $count_only; then ...; fi`, collapsing
+their 13-line block.
+
+HOW: TDD -- wrote two lib tests first (count output + exit 0; --json mutex -> failure +
+"mutually exclusive" on stderr, no count on stdout), confirmed command-not-found, then
+implemented. The wrapper takes a --json flag (consistent with the codebase's flag-based
+library functions); callers pass it only when $json_output is true via the two-branch
+idiom (do NOT use ${json_output:+--json} -- hug stores booleans as true/false strings, so
+:+ fires on the non-empty "false" too and would ALWAYS pass --json; caught by TDD in Task
+3). local is legal inside the
+function body; local -a pathspecs=("$@") keeps "${pathspecs[@]}" safe under set -u even
+when empty, matching the existing primitive. The terminating (not non-terminating)
+design is intentional: a $(...) capture returns the correct count but the caller does
+not terminate (broken output: count + listing fall-through) -- a benign contract
+violation, preferred over the non-terminating alternative whose forgotten exit 0 at any
+of 6 call sites would produce the same broken output with 6 chances instead of 1.
+
+IMPACT: Single source of truth for the -c dispatch is now in place (1 helper). The 6
+dispatchers are wired in the next commit. Documented the new function in the in-file
+header and git-config/lib/README.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 3: Wire the 6 `sl*` dispatchers to `run_count_mode`
+
+**Goal:** Replace the duplicated ~13-line `-c` count block in each of the 6 `sl*` dispatchers with a one-line `run_count_mode` call (and the `git-statusbase` two-branch variant), collapsing the DRY smell. Behavior is unchanged — pinned by the existing `sl* -c` unit tests.
+
+**Files:**
+- Modify: `git-config/bin/git-sls` (state: `staged`)
+- Modify: `git-config/bin/git-slu` (state: `unstaged`)
+- Modify: `git-config/bin/git-slk` (state: `untracked`)
+- Modify: `git-config/bin/git-sli` (state: `ignored`)
+- Modify: `git-config/bin/git-slc` (state: `conflicted`)
+- Modify: `git-config/bin/git-statusbase` (states: `all` / `all+untracked`, branch on `$include_untracked`)
+
+**Acceptance Criteria:**
+- [ ] Each of the 5 single-state dispatchers replaces its 13-line count block (the `# Count mode: ...` comment + the `if $count_only; then ... fi` block) with a 3-line `# Count mode: ...` pointer + `if $count_only; then run_count_mode ...; fi`.
+- [ ] `git-statusbase` keeps its `if $include_untracked` if/else but swaps the inner guard+exit for `run_count_mode` (inlining `all+untracked` vs `all` — no top-level `local`, which is fatal under `set -euo pipefail`).
+- [ ] The `~7`-line WHY comment is gone from all 6 call sites (it lives once in `run_count_mode`'s docblock); each site keeps a one-line pointer.
+- [ ] All existing `sl* -c` unit tests stay green unchanged: `hug slc -c: -c + --json errors (mutually exclusive)`, `hug slk -c: counts a newline-containing filename once (NUL-safe)`, the `slu -c` pathspec test, `sls`/`sli`/`sl`/`sla` `-c` tests.
+- [ ] `make sanitize` passes for all 6 edited dispatchers.
+
+**Verify:** `make test-unit TEST_FILE=test_status_staging.bats TEST_FILTER="-c" TEST_SHOW_ALL_RESULTS=1` → all `sl* -c` tests pass; then `make test` → full suite green; then `make sanitize` → clean.
+
+**Steps:**
+
+- [ ] **Step 1: Replace the count block in the 5 single-state dispatchers.**
+
+Each of `git-sls`, `git-slu`, `git-slk`, `git-sli`, `git-slc` contains this exact 13-line block (only the state argument on the `count_files_with_status <state>` line differs — `staged` / `unstaged` / `untracked` / `ignored` / `conflicted` respectively):
+
+```bash
+# Count mode: print the number of matching files (the grep -c of listings).
+# NUL-safe + Bash-4.0-safe via count_files_with_status (hug-select-files):
+# counts git's NUL-delimited records, so newline-containing filenames count
+# once, and no `local -n` nameref (Bash 4.3+) is reached. The count is the
+# whole answer: it suppresses the trailing summary and is mutually exclusive
+# with --json (like `hug wtl`'s --json --path-only error).
+if $count_only; then
+  if $json_output; then
+    error "-c/--count and --json are mutually exclusive"
+  fi
+  count_files_with_status <STATE> "${pathspecs[@]}"
+  exit 0
+fi
+```
+
+Replace the entire block (the 7-line comment + the 6-line `if`) with:
+
+```bash
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+# --json passed only when $json_output is true (the codebase stores booleans as
+# true/false strings; ${json_output:+--json} would ALWAYS expand — see run_count_mode).
+if $count_only; then
+  if $json_output; then
+    run_count_mode --json <STATE> "${pathspecs[@]}"
+  else
+    run_count_mode <STATE> "${pathspecs[@]}"
+  fi
+fi
+```
+
+Substitute `<STATE>` per file:
+- `git-sls` → `staged`
+- `git-slu` → `unstaged`
+- `git-slk` → `untracked`
+- `git-sli` → `ignored`
+- `git-slc` → `conflicted`
+
+(Confirm each block matches the "before" above by reading the file — they were verified identical except the state line. The `run_count_mode` function is sourced via `hug-select-files`, which each dispatcher already loads in its `for f in hug-common hug-git-kit hug-select-files output_json_status` line — no new source line needed.)
+
+- [ ] **Step 2: Replace the count block in `git-statusbase`.**
+
+`git-config/bin/git-statusbase` contains this 18-line block (it has an extra dedup comment line and an `if $include_untracked` if/else):
+
+```bash
+# Count mode: print the number of matching files (the grep -c of listings).
+# NUL-safe + Bash-4.0-safe via count_files_with_status (hug-select-files):
+# counts git's NUL-delimited records, so newline-containing filenames count
+# once, and no `local -n` nameref (Bash 4.3+) is reached. The count is the
+# whole answer: it suppresses the trailing summary and is mutually exclusive
+# with --json (like `hug wtl`'s --json --path-only error). all/all+untracked
+# dedup a file that is both staged and unstaged (one MM record in porcelain).
+if $count_only; then
+  if $json_output; then
+    error "-c/--count and --json are mutually exclusive"
+  fi
+  if $include_untracked; then
+    count_files_with_status all+untracked "${pathspecs[@]}"
+  else
+    count_files_with_status all "${pathspecs[@]}"
+  fi
+  exit 0
+fi
+```
+
+Replace the entire block with (a scratch var `_slc_state` selects `all+untracked` vs `all` — **no `local`**, which is fatal at script top level under `set -euo pipefail`; the dispatcher already uses non-local top-level vars like `pathspecs`/`list_opts`. Then the same two-branch over `$json_output`):
+
+```bash
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+# --json passed only when $json_output is true (the codebase stores booleans as
+# true/false strings; ${json_output:+--json} would ALWAYS expand — see run_count_mode).
+if $count_only; then
+  if $include_untracked; then _slc_state=all+untracked; else _slc_state=all; fi
+  if $json_output; then
+    run_count_mode --json "$_slc_state" "${pathspecs[@]}"
+  else
+    run_count_mode "$_slc_state" "${pathspecs[@]}"
+  fi
+fi
+```
+
+(The `all`/`all+untracked` dedup rationale that was in the dropped comment is relocated, not lost — it lives in `count_files_with_status`'s header and is summarized in `run_count_mode`'s docblock.)
+
+- [ ] **Step 3: Run the `sl* -c` unit tests.**
+
+Run: `make test-unit TEST_FILE=test_status_staging.bats TEST_FILTER="-c" TEST_SHOW_ALL_RESULTS=1`
+Expected: PASS — every `sl* -c` test passes unchanged. These tests pin the contract end-to-end: `hug slc -c: -c + --json errors (mutually exclusive)` (line ~1953), `hug slk -c: counts a newline-containing filename once (NUL-safe)` (line ~1966), the `slu -c` pathspec test (line ~1981), and the `sls`/`sli`/`sl`/`sla` `-c` tests (lines ~1996-2019). If any fails, the dispatcher wiring diverged from the original semantics — re-check the state argument and that `--json` is passed via the two-branch `if $json_output` idiom (NOT `${json_output:+--json}`, which is broken for true/false-string booleans).
+
+- [ ] **Step 4: Run the full suite.**
+
+Run: `make test`
+Expected: PASS (all BATS + pytest). This catches any cross-command regression.
+
+- [ ] **Step 5: Run shellcheck on the edited dispatchers.**
+
+Run: `make sanitize`
+Expected: clean (the edits remove code, not add constructs; `run_count_mode` is the only new construct and it lives in the already-checked `hug-select-files`).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+cd /home/ecc/src/hug-scm.WT.refactor-sl-count-engine-258-259
+hug a git-config/bin/git-sls git-config/bin/git-slu git-config/bin/git-slk git-config/bin/git-sli git-config/bin/git-slc git-config/bin/git-statusbase
+hug c -F - <<'EOF' # GIT-BLOCK:BYPASS
+refactor(sl*): wire the 6 sl* dispatchers to run_count_mode (#258)
+
+WHY: With run_count_mode now in hug-select-files (previous commit), the 6 sl* dispatchers
+can each drop their ~13-line duplicated -c count block (and its ~7-line WHY comment) for a
+one-line call. Single source of truth: any future change to -c semantics is now one edit,
+not six.
+
+WHAT: Replaced the count block in git-sls (staged), git-slu (unstaged), git-slk (untracked),
+git-sli (ignored), git-slc (conflicted), and git-statusbase (all / all+untracked) with
+`run_count_mode` calls inside `if $count_only; then ...; fi`, using the two-branch
+`if $json_output; then run_count_mode --json <state> ...; else run_count_mode <state> ...; fi`
+idiom (do NOT use ${json_output:+--json} -- broken for true/false-string booleans).
+git-statusbase keeps its if/else over $include_untracked, inlining the state
+(all vs all+untracked) -- no top-level `local`, which is fatal under set -euo pipefail.
+The ~7-line WHY comment is gone from all 6 sites; it lives once in run_count_mode's
+docblock, and each site carries a one-line pointer. sl/sla delegate to git-statusbase via
+.gitconfig aliases, so they are covered transitively.
+
+HOW: Behavior-preserving by construction -- run_count_mode encapsulates exactly the
+mutual-exclusion guard + count_files_with_status call + exit 0 that each block had (the
+--json check runs before count_files_with_status, matching the original ordering). The
+existing sl* -c unit tests (slc -c --json mutex, slk -c NUL-safety, slu -c pathspec,
+sls/sli/sl/sla -c) pin the contract end-to-end and stay green unchanged.
+
+IMPACT: 6 near-verbatim copies of a 13-line block collapse to one helper + six one-line
+calls. The sl* -c engine is now DRY; the count_files_with_status primitive (which now
+checks the repo, #259) is reached only through the wrapper in production.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- #259 (`check_git_repo` first line of `count_files_with_status`, declare `hug-git-repo` dep, non-repo clean error) → Task 1. ✓
+- #258 (`run_count_mode` wrapper in `hug-select-files`, terminating, `--json` mutex, 6 dispatchers collapse) → Task 2 (helper + tests) + Task 3 (wire dispatchers). ✓
+- Doc-perimeter (`git-config/lib/README.md` — `run_count_mode` entry + amended `count_files_with_status` contract) → Task 1 (amend) + Task 2 (add). ✓
+- In-file header comment (function list + repo-precondition note) → Task 1 (count_files_with_status line + Depends-on) + Task 2 (run_count_mode line). ✓
+- Implementation order forced #259 then #258 → Task 1 before Task 2 before Task 3. ✓
+- Out-of-scope arg-parsing hardening → tracked as #260, referenced in the header; not implemented here. ✓
+- Risks (top-level `local` footgun in `git-statusbase`) → Task 3 Step 2 inlines the state, explicitly notes no `local`. ✓
+- Risks (terminating helper) → Task 2 docblock + commit message document it. ✓
+
+**2. Placeholder scan:** No TBD/TODO/"implement later"/"add appropriate error handling". Each step contains the actual code. State arguments are concretely substituted per file (no `<STATE>` left in a final artifact — it's a template with an explicit per-file substitution list). ✓
+
+**3. Type consistency:** `run_count_mode` signature `[--json] <state> [pathspec...]` is identical in Task 2 (definition), Task 3 (call sites), the README entry, and the header comment. `count_files_with_status` signature unchanged. The two-branch `if $json_output` call-site idiom is identical at all 6 sites (NOT `${json_output:+--json}`, which is broken for true/false-string booleans — see the Implementation note in the spec). ✓
+
+**4. Ambiguity check:** The `git-statusbase` "no `local`" constraint is called out explicitly (the one place a reader might reach for a temp var). The `--separate-stderr` test convention is pinned to an existing repo test (`test_status_staging.bats:1947`). ✓
+
+---
+
+## Notes for the executor
+
+- **Worktree CWD:** the Bash tool resets CWD between calls. Every `cd`/`make`/`hug` command in this plan either starts with `cd /home/ecc/src/hug-scm.WT.refactor-sl-count-engine-258-259` or is run after one. Do not run `make`/tests from the main checkout — run them inside the worktree.
+- **Known local-only test flakes (NOT regressions):** if `make test-lib` fails `test_hug-file-input.bats` (global `core.excludesFile` lists `.env`) or `test_hug-common.bats` (symlinked-checkout `HUG_HOME` mismatch), those are pre-existing environment issues (elifarley/hug-scm#197, #198), green in CI — not caused by this work. Investigate only if a `count_files_with_status` / `run_count_mode` / `sl* -c` test fails.
+- **`GIT-BLOCK:BYPASS`:** the commit bodies reference git internals (`git rev-parse`, `git status --porcelain`), which the `block-commands.py` hook string-matches. The trailing `# GIT-BLOCK:BYPASS` comment after the heredoc opener bypasses the hook without polluting the message. (See `.wolf/cerebrum.md`.)

--- a/docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md
@@ -1,0 +1,278 @@
+# Design: `sl* -c` count engine refactor — `run_count_mode` wrapper + `check_git_repo` parity
+
+**Issues:** [elifarley/hug-scm#258](https://github.com/elifarley/hug-scm/issues/258),
+[elifarley/hug-scm#259](https://github.com/elifarley/hug-scm/issues/259)
+**Tracked from:** PR [elifarley/hug-scm#257](https://github.com/elifarley/hug-scm/pull/257) (v1.7.0, the `-c/--count` feature)
+**Branch:** `refactor-sl-count-engine-258-259`
+**Date:** 2026-08-07
+
+## Summary
+
+Two tech-debt follow-ups from the `-c/--count` feature, batched into one design +
+one PR because both touch the same file (`git-config/lib/hug-select-files`) and the
+same test file, and they compose: #259 hardens the count *primitive*, #258 wraps it.
+
+- **#258:** The `-c/--count` dispatch block (mutual-exclusion guard + `count_files_with_status`
+  call + `exit 0`, ~14 lines) plus its ~7-line WHY comment are duplicated verbatim across
+  the 6 `sl*` dispatchers that implement `-c` locally — `git-sls`, `git-slu`, `git-slk`,
+  `git-sli`, `git-slc`, `git-statusbase`. Only the state argument differs. Factor the
+  shared logic into a single `run_count_mode` helper.
+- **#259:** `count_files_with_status` (the `sl* -c` engine) does not call `check_git_repo`,
+  unlike every `list_*_files` function in `hug-git-files`. All current `sl*` callers
+  validate at the top of their script, so the gap is defended in practice — but a direct
+  library caller gets a raw git error instead of the clean HUG "Not in a git repository"
+  message. Add `check_git_repo` for parity.
+
+## Decisions (settled during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **#259 approach** | Unconditional `check_git_repo` as the first line of `count_files_with_status` | Matches the `list_*_files` contract verbatim; simplest. `count_files_with_status` already spawns ≥1 git subprocess per call, so one extra `git rev-parse --git-dir` is negligible. A cached-sentinel guard adds state to a pure helper for a micro-optimization — YAGNI. Guarding in `run_count_mode` only does **not** meet #259's acceptance (a direct library caller still gets a raw git error). |
+| **Scope & PR shape** | One combined design, one PR | Both touch `hug-select-files` + `test_hug-select-files.bats`; #258's wrapper delegates to #259's hardened primitive. Matches the repo's batch precedent (visibility batch #207+#208, head-mover correctness batch). |
+| **Implementation order** | #259 first, then #258 | Forced: the wrapper delegates to the primitive, so the primitive must carry the invariant first. |
+
+## Architecture
+
+Single library module, two stacked edits, no new files.
+
+```
+git-config/lib/hug-select-files
+  ├── run_count_mode [--json] <state> [pathspec...]   # NEW (#258) — terminating wrapper
+  └── count_files_with_status <state> [pathspec...]   # MODIFIED (#259) — +check_git_repo first line
+
+git-config/bin/git-sls        # MODIFIED — 14-line block → 1-line call (state: staged)
+git-config/bin/git-slu        # MODIFIED — (state: unstaged)
+git-config/bin/git-slk        # MODIFIED — (state: untracked)
+git-config/bin/git-sli        # MODIFIED — (state: ignored)
+git-config/bin/git-slc        # MODIFIED — (state: conflicted)
+git-config/bin/git-statusbase # MODIFIED — (state: all / all+untracked, branch on $include_untracked)
+
+# sl / sla delegate to git-statusbase via .gitconfig aliases → covered transitively, no own copy.
+```
+
+`hug-select-files` is loaded by all 6 dispatchers (they source
+`hug-common hug-git-kit hug-select-files output_json_status`). `hug-git-kit` aggregates
+`hug-git-repo` (provides `check_git_repo`) and `hug-output` (provides `error`), so both
+are already in scope wherever `count_files_with_status` runs — the existing `error` call
+for unknown state (line ~106) already relies on this chain.
+
+## Section 1 — `count_files_with_status` parity (#259)
+
+Insert `check_git_repo` as the first executable line of `count_files_with_status()`,
+before arg parsing. Update the header comment to note the repo precondition is enforced
+internally (matching `list_*_files`).
+
+```bash
+count_files_with_status() {
+  check_git_repo   # Parity with list_*_files: clean HUG error from any context (#259)
+  local state="$1"
+  shift
+  local -a pathspecs=("$@")
+  local count=0
+  ...
+}
+```
+
+**Why the first line, before arg parsing:** mirrors `list_*_files` (which calls
+`check_git_repo` early) and fails fast with the clean message before spending a
+subprocess on a doomed count. `check_git_repo`'s `error`→`exit 1` propagates from any
+call context (top-level script, or a `run` subshell in tests); when the caller already
+validated, the single `git rev-parse --git-dir` is a no-op pass. No behavior change for
+any existing in-repo caller — the entire `sl* -c` test suite cds into a repo first.
+
+## Section 2 — `run_count_mode` wrapper (#258)
+
+Add directly above `count_files_with_status` in `hug-select-files`:
+
+```bash
+# run_count_mode — terminating wrapper for the sl* -c/--count dispatch.
+# Usage: run_count_mode [--json] <state> [pathspec...]
+#   <state>: the count_files_with_status enum (staged|unstaged|untracked|ignored|
+#           conflicted|all|all+untracked).
+# Encapsulates the -c dispatch previously duplicated verbatim across the 6 sl*
+# scripts (git-sls/slu/slk/sli/slc/statusbase):
+#   (1) --json is mutually exclusive with -c → error + exit (like hug wtl's
+#       --json --path-only error),
+#   (2) delegate to count_files_with_status (which itself enforces the repo
+#       precondition — #259),
+#   (3) exit 0.
+# TERMINATING: calls `exit 0`, so a caller running this inside
+#   `if $count_only; then ...; fi` never reaches code below the block. Pass
+#   `--json` with `${json_output:+--json}` so the caller stays a single line.
+# Why NUL-delimited + Bash-4.0-safe: see count_files_with_status.
+run_count_mode() {
+  local json=false
+  [[ "${1:-}" == --json ]] && { json=true; shift; }
+  local state="$1"; shift
+  local -a pathspecs=("$@")
+  if $json; then
+    error "-c/--count and --json are mutually exclusive"
+  fi
+  count_files_with_status "$state" "${pathspecs[@]}"
+  exit 0
+}
+```
+
+### Contract decisions
+
+- **`--json` as a flag, passed via `${json_output:+--json}`** — keeps each call site a
+  single line and the helper self-contained (no reliance on a caller global variable
+  name). The mutual-exclusion check lives inside the helper, so it cannot drift across
+  the 6 sites.
+- **Terminating (`exit 0`)** — matches #258's "(3) the exit 0" and the original blocks.
+  Callers are top-level scripts that intend to terminate; none capture `run_count_mode`
+  in `$(...)`, so the known "exit only exits the subshell" footgun (helpers captured via
+  command substitution) does not apply.
+- **`local` is safe here** — this is a real function body (unlike the dispatcher
+  top-level code), so `local` is legal under `set -euo pipefail`. The cerebrum's
+  "local at top level is a fatal bash error" warning applies only to the dispatcher
+  scripts' top-level code, not to this function.
+- **Bash-floor safety** — `local -a pathspecs=("$@")` declares the array, so
+  `"${pathspecs[@]}"` is safe under `set -u` even when empty, exactly as in the existing
+  `count_files_with_status` (declared arrays are "set" even when empty).
+- **Module header hygiene** — add `run_count_mode` to the function list in the
+  `hug-select-files` header comment (lines 1-9) alongside `count_files_with_status`.
+
+## Section 3 — Call-site transformation (6 dispatchers)
+
+The WHY comment (currently ~7 lines, duplicated 6×) moves into `run_count_mode`'s
+docblock (Section 2). Each call site keeps a one-line pointer.
+
+### 5 single-state dispatchers
+
+`git-sls` (staged), `git-slu` (unstaged), `git-slk` (untracked), `git-sli` (ignored),
+`git-slc` (conflicted) — identical shape. Example, `git-sls`:
+
+Before (~14-line block + ~7-line comment):
+```bash
+# Count mode: print the number of matching files (the grep -c of listings).
+# NUL-safe + Bash-4.0-safe via count_files_with_status (hug-select-files):
+# counts git's NUL-delimited records, so newline-containing filenames count
+# once, and no `local -n` nameref (Bash 4.3+) is reached. The count is the
+# whole answer: it suppresses the trailing summary and is mutually exclusive
+# with --json (like `hug wtl`'s --json --path-only error).
+if $count_only; then
+  if $json_output; then
+    error "-c/--count and --json are mutually exclusive"
+  fi
+  count_files_with_status staged "${pathspecs[@]}"
+  exit 0
+fi
+```
+
+After:
+```bash
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+if $count_only; then
+  run_count_mode ${json_output:+--json} staged "${pathspecs[@]}"
+fi
+```
+
+### `git-statusbase` (branches `all` vs `all+untracked`)
+
+Keeps its existing `if $include_untracked` if/else, swapping the inner guard+exit for
+`run_count_mode`. No `local` (top-level, `set -e` footgun), so the two branches inline
+the state:
+
+```bash
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+if $count_only; then
+  if $include_untracked; then
+    run_count_mode ${json_output:+--json} all+untracked "${pathspecs[@]}"
+  else
+    run_count_mode ${json_output:+--json} all "${pathspecs[@]}"
+  fi
+fi
+```
+
+(`sl` / `sla` are `.gitconfig` aliases to `git-statusbase`, so they are covered
+transitively — no own copy to touch, exactly as #258 notes.)
+
+## Section 4 — Tests & verification
+
+### No-regression (existing tests, unchanged)
+
+- `tests/lib/test_hug-select-files.bats` lines 757+: per-state counts, dedup, pathspec
+  scoping, NUL-safety, rename handling, untracked-dir expansion. All `cd "$repo"` first,
+  so the new `check_git_repo` passes and they stay green unchanged.
+- `tests/unit/test_status_staging.bats`: the `sl* -c` unit tests — including
+  `hug slc -c: -c + --json errors (mutually exclusive)` (line 1953), `hug slk -c: counts
+  a newline-containing filename once (NUL-safe)` (line 1966), and the `slu -c` pathspec
+  test (line 1981) — pin the contract end-to-end and stay green.
+
+### New test for #259
+
+In `test_hug-select-files.bats`, next to the `count_files_with_status` block:
+
+```bash
+@test "count_files_with_status: clean error outside a git repo (parity with list_*_files)" {
+  cd /tmp  # setup() cds into a repo; leave it for this assertion
+  run count_files_with_status staged
+  assert_failure
+  assert_output --partial "Not in a git repository"
+}
+```
+
+Convention matches `test_worktree_list.bats:142` (`cd /tmp; run git-wt; assert_failure;
+assert_output --partial "Not in a git repository"`). `check_git_repo` and `error` are in
+scope via `hug-git-kit` (already loaded at line 6 of the test file); `run` runs in a
+subshell that inherits the sourced function, and `error`→`exit 1` is contained there.
+
+### Optional end-to-end test (only if it does not duplicate the lib test)
+
+A `hug sls -c` from `/tmp` asserting the same "Not in a git repository" message —
+confirms the wrapper + primitive compose end-to-end. Add **only** if it proves cheaper
+than it is duplicative; the lib test above is the load-bearing one for #259's acceptance.
+
+### Verify commands
+
+```bash
+make test-lib TEST_FILE=test_hug-select-files.bats TEST_SHOW_ALL_RESULTS=1
+make test-unit TEST_FILE=test_status_staging.bats TEST_FILTER="-c" TEST_SHOW_ALL_RESULTS=1
+make sanitize   # shellcheck: run_count_mode's local usage + the 6 call-site edits
+make test       # full suite before commit
+```
+
+## Acceptance criteria
+
+Mapped to the two issues:
+
+- **#258:**
+  - [ ] Single source of truth for the `-c` dispatch logic (1 `run_count_mode` helper,
+        6 one-line call sites).
+  - [ ] The ~7-line WHY comment lives once in `run_count_mode`'s docblock; call sites
+        carry a one-line pointer.
+  - [ ] All `sl* -c` behavior unchanged (pinned by the existing `sl* -c` unit tests,
+        which stay green without modification).
+- **#259:**
+  - [ ] `count_files_with_status` calls `check_git_repo` as its first line.
+  - [ ] `count_files_with_status` from a non-repo directory emits the HUG "Not in a git
+        repository" message, not raw git stderr (new lib test).
+  - [ ] No regression to in-repo `count_files_with_status` callers (existing lib tests
+        green unchanged).
+
+## Out of scope (YAGNI)
+
+- A cached "already-validated" sentinel to avoid the extra `git rev-parse` on repeat
+  calls — rejected during brainstorming; the cost is negligible and the sentinel adds
+  state to a pure helper.
+- Moving `check_git_repo` into `run_count_mode` only — rejected; does not satisfy #259's
+  acceptance for direct library callers.
+- Refactoring the `sl*` JSON/listing paths (out of scope; only the `-c` dispatch is
+  factored).
+- Touching `sl`/`sla` directly (they delegate via aliases).
+
+## Risks
+
+- **Top-level `local` footgun:** the `git-statusbase` branch must not introduce a
+  `local state=...` at script top level (fatal under `set -euo pipefail`). The design
+  inlines the state in two `run_count_mode` calls instead. The `git-sls` family is
+  unaffected (single state, no temp var).
+- **Terminating helper captured via `$(...)`:** if a future caller captures
+  `run_count_mode` in command substitution, `exit 0` only exits the subshell and the
+  caller continues — a silent no-op. Mitigated by the docblock's TERMINATING note and by
+  the contract (callers invoke it as a statement inside `if $count_only; then ...; fi`).
+- **`--json` flag parsing vs. pathspecs starting with `--`:** a pathspec literally named
+  `--json` would be mis-read as the flag. This is already broken upstream (the
+  dispatchers' `case` collects anything not matching `--json`/`-c`/`-q` as a pathspec, so
+  a real `--json` pathspec can't reach `run_count_mode` anyway). No new exposure.

--- a/docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md
@@ -145,12 +145,15 @@ Add directly above `count_files_with_status` in `hug-select-files`:
 #   (3) exit 0.
 # TERMINATING: calls `exit 0` (and `error`→exit 1 on the --json violation), so it
 #   NEVER returns — a caller running it inside `if $count_only; then ...; fi` never
-#   reaches code below the block. Pass `--json` with `${json_output:+--json}` so the
-#   caller stays a single line. Do NOT capture this in $(...) : the subshell exit is
-#   contained and the count is captured correctly, but the caller does NOT terminate
-#   — in the dispatchers, execution falls through to the listing/summary code and
-#   prints BOTH the (captured) count AND the listing (broken output). Call it as a
-#   statement, never as a substitution.
+#   reaches code below the block. Callers pass `--json` only when their json flag is
+#   true, e.g. `if $json_output; then run_count_mode --json <state> ...; else
+#   run_count_mode <state> ...; fi`. Do NOT use ${json_output:+--json}: hug stores
+#   booleans as the strings true/false, so :+ fires on the non-empty "false" too and
+#   would ALWAYS pass --json (making every -c invocation error as mutually exclusive).
+#   Do NOT capture this in $(...) : the subshell exit is contained and the count is
+#   captured correctly, but the caller does NOT terminate — in the dispatchers,
+#   execution falls through to the listing/summary code and prints BOTH the (captured)
+#   count AND the listing (broken output). Call it as a statement, never as a substitution.
 run_count_mode() {
   local json=false
   [[ "${1:-}" == --json ]] && { json=true; shift; }
@@ -166,10 +169,16 @@ run_count_mode() {
 
 ### Contract decisions
 
-- **`--json` as a flag, passed via `${json_output:+--json}`** — keeps each call site a
-  single line and the helper self-contained (no reliance on a caller global variable
-  name). The mutual-exclusion check lives inside the helper, so it cannot drift across
-  the 6 sites.
+- **`--json` as a flag, passed via the two-branch `if $json_output` idiom** — the caller
+  writes `if $json_output; then run_count_mode --json <state> ...; else run_count_mode
+  <state> ...; fi` (the codebase's established conditional-flag pattern, e.g.
+  git-statusbase's own `if $include_untracked; then list_opts+=(--untracked); fi`). The
+  mutual-exclusion check lives inside the helper, so it cannot drift across the 6 sites.
+  **Do NOT use `${json_output:+--json}`** — hug stores booleans as the strings
+  `"true"`/`"false"`, so `:+` fires on the non-empty `"false"` too and would ALWAYS pass
+  `--json` (every `-c` invocation would error as mutually exclusive). This was a defect in
+  earlier drafts of this spec (caught by TDD when all 16 `sl* -c` tests failed; missed by
+  3 roast rounds). See §Implementation note (json-flag idiom) below.
 - **Terminating (`exit 0`)** — matches #258's "(3) the exit 0" and the original blocks.
   Callers are top-level scripts that intend to terminate; none capture `run_count_mode`
   in `$(...)`. The helper **always exits** (error→exit 1 on the `--json` violation, exit 0
@@ -226,23 +235,28 @@ After:
 ```bash
 # Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
 if $count_only; then
-  run_count_mode ${json_output:+--json} staged "${pathspecs[@]}"
+  if $json_output; then
+    run_count_mode --json staged "${pathspecs[@]}"
+  else
+    run_count_mode staged "${pathspecs[@]}"
+  fi
 fi
 ```
 
 ### `git-statusbase` (branches `all` vs `all+untracked`)
 
 Keeps its existing `if $include_untracked` if/else, swapping the inner guard+exit for
-`run_count_mode`. No `local` (top-level, `set -e` footgun), so the two branches inline
-the state:
+`run_count_mode`. No `local` (top-level, `set -e` footgun), so a scratch var `_slc_state`
+selects `all+untracked` vs `all`, then the same two-branch over `$json_output`:
 
 ```bash
 # Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
 if $count_only; then
-  if $include_untracked; then
-    run_count_mode ${json_output:+--json} all+untracked "${pathspecs[@]}"
+  if $include_untracked; then _slc_state=all+untracked; else _slc_state=all; fi
+  if $json_output; then
+    run_count_mode --json "$_slc_state" "${pathspecs[@]}"
   else
-    run_count_mode ${json_output:+--json} all "${pathspecs[@]}"
+    run_count_mode "$_slc_state" "${pathspecs[@]}"
   fi
 fi
 ```
@@ -484,6 +498,28 @@ call sites).
   path the default.
 - The project already has terminating helpers (`handle_upstream_operation` `exit 0`s
   internally, per cerebrum).
+
+### Implementation note — the json-flag idiom (TDD-caught defect, post-roast)
+
+Early drafts of this spec (and the plan transcribed from it) prescribed passing `--json`
+at the call sites via `${json_output:+--json}`. That idiom is **broken** in this codebase:
+hug stores booleans as the literal strings `"true"`/`"false"`, and `${var:+word}` fires on
+ANY non-empty value — so `${json_output:+--json}` ALWAYS expands to `--json` (even when
+`json_output="false"`), making every `hug sl* -c` error as "mutually exclusive." This was
+caught by TDD during Task 3 (all 16 `sl* -c` unit tests failed on the first run with the
+`: +` form) — a defect that **3 spec-roast rounds missed** (the roasts verified the
+function body but not the call-site expansion semantics against the codebase's boolean
+convention). Corrected to the two-branch `if $json_output; then run_count_mode --json
+<state> ...; else run_count_mode <state> ...; fi` idiom — the codebase's established
+conditional-flag pattern (e.g. `git-statusbase`'s own `if $include_untracked; then
+list_opts+=(--untracked); fi`), which is regression-proof (no one will "simplify" an
+obvious two-branch back to `:+`). The `run_count_mode` docblock carries the "Do NOT use
+${json_output:+--json}" warning with the rationale. `run_count_mode`'s `[--json] <state>
+[pathspec...]` interface is UNCHANGED (consistent with the codebase's flag-based library
+functions like `list_files_with_status --staged`). Lesson: when a spec proposes a shell
+parameter-expansion idiom for conditionally passing a flag, verify it against how the
+codebase actually stores the controlling boolean — `${var:+word}` and a true/false-string
+boolean are a footgun combination.
 
 **Disposition:** kept the terminating helper; sharpened the docblock (the `$(...)`-capture
 behavior is now explicit) and the Risks section. The "always exits, never returns"

--- a/docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md
@@ -13,21 +13,29 @@ one PR because both touch the same file (`git-config/lib/hug-select-files`) and 
 same test file, and they compose: #259 hardens the count *primitive*, #258 wraps it.
 
 - **#258:** The `-c/--count` dispatch block (mutual-exclusion guard + `count_files_with_status`
-  call + `exit 0`, ~14 lines) plus its ~7-line WHY comment are duplicated verbatim across
-  the 6 `sl*` dispatchers that implement `-c` locally — `git-sls`, `git-slu`, `git-slk`,
-  `git-sli`, `git-slc`, `git-statusbase`. Only the state argument differs. Factor the
-  shared logic into a single `run_count_mode` helper.
+  call + `exit 0`, ~14 lines) plus its ~7-line WHY comment are duplicated near-verbatim
+  across the 6 `sl*` dispatchers that implement `-c` locally — `git-sls`, `git-slu`,
+  `git-slk`, `git-sli`, `git-slc`, `git-statusbase`. Only the state argument differs in the
+  5 single-state scripts; `git-statusbase` additionally branches `all` vs `all+untracked`
+  on `$include_untracked` (and carries an extra dedup note). Factor the shared logic into
+  a single `run_count_mode` helper.
 - **#259:** `count_files_with_status` (the `sl* -c` engine) does not call `check_git_repo`,
   unlike every `list_*_files` function in `hug-git-files`. All current `sl*` callers
   validate at the top of their script, so the gap is defended in practice — but a direct
-  library caller gets a raw git error instead of the clean HUG "Not in a git repository"
-  message. Add `check_git_repo` for parity.
+  library caller outside a repo gets a **silent wrong answer** (`0`, exit 0) when not under
+  `set -e`, or a **silent crash** (no output, no diagnostic, exit 128) when under
+  `set -euo pipefail` — because every `git` call in `count_files_with_status` is suffixed
+  `2>/dev/null`, suppressing git's own error. Neither is a "raw git error"; both are *worse*
+  (no diagnostic at all). Add `check_git_repo` for parity with `list_*_files`, which emits
+  the clean HUG "Not in a git repository" message. (Verified empirically from `/tmp` —
+  see Roast hardening §F-003.)
 
 ## Decisions (settled during brainstorming)
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| **#259 approach** | Unconditional `check_git_repo` as the first line of `count_files_with_status` | Matches the `list_*_files` contract verbatim; simplest. `count_files_with_status` already spawns ≥1 git subprocess per call, so one extra `git rev-parse --git-dir` is negligible. A cached-sentinel guard adds state to a pure helper for a micro-optimization — YAGNI. Guarding in `run_count_mode` only does **not** meet #259's acceptance (a direct library caller still gets a raw git error). |
+| **#259 approach** | Unconditional `check_git_repo` as the first line of `count_files_with_status` | Matches the `list_*_files` contract; simplest. `count_files_with_status` already spawns ≥1 git subprocess per call, so one extra `git rev-parse --git-dir` is negligible. A cached-sentinel guard adds state to a pure helper for a micro-optimization — YAGNI. Guarding in `run_count_mode` only does **not** meet #259's acceptance (a direct library caller still gets a silent wrong answer / silent crash, not the clean HUG message). |
+| **#259 dependency (`check_git_repo` availability)** | Declare `hug-git-repo` in `hug-select-files`'s `Depends on:` header; do **not** auto-source it | `count_files_with_status` lives in `hug-select-files` (the shared `hug-common` bundle), while its `list_*_files` siblings live in `hug-git-files` (the `hug-git-kit` bundle, which co-loads `hug-git-repo`). All 6 `sl*` dispatchers source `hug-git-kit`, so `check_git_repo` is available to every real caller — #259's acceptance is met. Auto-sourcing `hug-git-repo` inside `hug-select-files` was **rejected** on VCS-boundary grounds: `hug-common` is symlinked into `hg-config`, so `hug-select-files` already loads in Mercurial contexts, and injecting the git-specific `check_git_repo` (which calls `git rev-parse`) there is wrong. Adding `hug-git-repo` to `hug-common`'s bundle is rejected for the same reason (shared bundle, git-specific dep). See Roast hardening §F-001. |
 | **Scope & PR shape** | One combined design, one PR | Both touch `hug-select-files` + `test_hug-select-files.bats`; #258's wrapper delegates to #259's hardened primitive. Matches the repo's batch precedent (visibility batch #207+#208, head-mover correctness batch). |
 | **Implementation order** | #259 first, then #258 | Forced: the wrapper delegates to the primitive, so the primitive must carry the invariant first. |
 
@@ -47,20 +55,52 @@ git-config/bin/git-sli        # MODIFIED — (state: ignored)
 git-config/bin/git-slc        # MODIFIED — (state: conflicted)
 git-config/bin/git-statusbase # MODIFIED — (state: all / all+untracked, branch on $include_untracked)
 
+git-config/lib/README.md      # MODIFIED — add run_count_mode entry + amend count_files_with_status contract (doc-perimeter)
+
 # sl / sla delegate to git-statusbase via .gitconfig aliases → covered transitively, no own copy.
 ```
 
-`hug-select-files` is loaded by all 6 dispatchers (they source
-`hug-common hug-git-kit hug-select-files output_json_status`). `hug-git-kit` aggregates
-`hug-git-repo` (provides `check_git_repo`) and `hug-output` (provides `error`), so both
-are already in scope wherever `count_files_with_status` runs — the existing `error` call
-for unknown state (line ~106) already relies on this chain.
+`hug-select-files` is sourced by all 6 dispatchers alongside `hug-common hug-git-kit`
+(they source `hug-common hug-git-kit hug-select-files output_json_status`). The two
+functions this design touches enter through **different** aggregator modules:
+
+- `error` (used by the existing unknown-state branch, line ~106, and by the new
+  `--json` mutex check) is defined in `hug-output`, loaded by **`hug-common`** (line 83 of
+  `hug-common`'s `_hug_common_libs`).
+- `check_git_repo` (new, #259) is defined in `hug-git-repo`, loaded by **`hug-git-kit`**
+  (line 30 of `hug-git-kit`'s module loop). `hug-common` does **not** load `hug-git-repo`.
+
+Both are in scope wherever `count_files_with_status` runs *in production*, because every
+`sl*` dispatcher sources both `hug-common` and `hug-git-kit`.
+
+**Structural asymmetry (root of F-001):** `count_files_with_status` lives in
+`hug-select-files`, which is bundled in the **shared** `hug-common` (`_hug_common_libs`,
+line 90). Its `list_*_files` siblings live in `hug-git-files`, bundled in `hug-git-kit`
+(which co-loads `hug-git-repo` in the same loop). So `list_*_files` gets `check_git_repo`
+for free from its bundle; `count_files_with_status` does not — its bundle (`hug-common`)
+doesn't carry `hug-git-repo`. The fix is to **declare** `hug-git-repo` in `hug-select-files`'s
+`Depends on:` header (line 5) so the new dependency is honest and discoverable, matching the
+codebase convention (modules declare deps; the caller sources them — `git-g` itself sources
+`hug-git-repo` explicitly at line 11 for exactly this reason). We do **not** auto-source
+`hug-git-repo` from `hug-select-files`: `hug-common` is symlinked into `hg-config/lib`, so
+`hug-select-files` already loads in Mercurial contexts, and defensively sourcing the
+git-specific `hug-git-repo` (whose `check_git_repo` calls `git rev-parse`) there would
+inject git-only semantics into the hg path. See Roast hardening §F-001 for the rejected
+alternatives.
 
 ## Section 1 — `count_files_with_status` parity (#259)
 
 Insert `check_git_repo` as the first executable line of `count_files_with_status()`,
-before arg parsing. Update the header comment to note the repo precondition is enforced
-internally (matching `list_*_files`).
+before arg parsing. This replaces the current non-repo behavior — a **silent wrong answer**
+(`0`, exit 0) without `set -e`, or a **silent crash** (no output, no diagnostic, exit 128)
+with `set -euo pipefail`, because every `git` call is suffixed `2>/dev/null` — with the
+clean HUG "Not in a git repository" message (verified empirically; see §F-003).
+
+Two header-comment edits in the same file:
+- The `Depends on:` line (line 5): append `hug-git-repo (for check_git_repo)` — declares the
+  new dependency honestly (see Architecture / §F-001).
+- The function-list block (lines 6-9): note the repo precondition is now enforced internally
+  (matching `list_*_files`).
 
 ```bash
 count_files_with_status() {
@@ -80,6 +120,13 @@ call context (top-level script, or a `run` subshell in tests); when the caller a
 validated, the single `git rev-parse --git-dir` is a no-op pass. No behavior change for
 any existing in-repo caller — the entire `sl* -c` test suite cds into a repo first.
 
+**Availability of `check_git_repo`:** provided by `hug-git-repo`, which all 6 `sl*`
+dispatchers load via `hug-git-kit`. A caller that sources only `hug-common` (which loads
+`hug-select-files` but not `hug-git-repo`) must source `hug-git-repo` itself, as the
+`Depends on:` header now declares — the same contract every other module in this codebase
+uses (callers source declared deps; `git-g` does this explicitly at line 11). #259's
+acceptance is met for every real caller.
+
 ## Section 2 — `run_count_mode` wrapper (#258)
 
 Add directly above `count_files_with_status` in `hug-select-files`:
@@ -89,17 +136,19 @@ Add directly above `count_files_with_status` in `hug-select-files`:
 # Usage: run_count_mode [--json] <state> [pathspec...]
 #   <state>: the count_files_with_status enum (staged|unstaged|untracked|ignored|
 #           conflicted|all|all+untracked).
-# Encapsulates the -c dispatch previously duplicated verbatim across the 6 sl*
+# Encapsulates the -c dispatch previously duplicated (near-verbatim) across the 6 sl*
 # scripts (git-sls/slu/slk/sli/slc/statusbase):
 #   (1) --json is mutually exclusive with -c → error + exit (like hug wtl's
 #       --json --path-only error),
 #   (2) delegate to count_files_with_status (which itself enforces the repo
 #       precondition — #259),
 #   (3) exit 0.
-# TERMINATING: calls `exit 0`, so a caller running this inside
-#   `if $count_only; then ...; fi` never reaches code below the block. Pass
-#   `--json` with `${json_output:+--json}` so the caller stays a single line.
-# Why NUL-delimited + Bash-4.0-safe: see count_files_with_status.
+# TERMINATING: calls `exit 0` (and `error`→exit 1 on the --json violation), so it
+#   NEVER returns — a caller running it inside `if $count_only; then ...; fi` never
+#   reaches code below the block. Pass `--json` with `${json_output:+--json}` so the
+#   caller stays a single line. Do NOT capture this in $(...) : the subshell exit is
+#   contained, the count is captured correctly, but the caller does NOT terminate
+#   (silent non-termination) — call it as a statement, never as a substitution.
 run_count_mode() {
   local json=false
   [[ "${1:-}" == --json ]] && { json=true; shift; }
@@ -121,8 +170,15 @@ run_count_mode() {
   the 6 sites.
 - **Terminating (`exit 0`)** — matches #258's "(3) the exit 0" and the original blocks.
   Callers are top-level scripts that intend to terminate; none capture `run_count_mode`
-  in `$(...)`, so the known "exit only exits the subshell" footgun (helpers captured via
-  command substitution) does not apply.
+  in `$(...)`. The helper **always exits** (error→exit 1 on the `--json` violation, exit 0
+  on success) — a uniform "never returns" contract, which is clearer than a mixed
+  "exits on error, returns on success." A non-terminating variant (helper returns, each
+  call site adds `; exit 0`) was **considered and rejected**: it trades the benign
+  `$(...)`-capture case (which returns the *correct* count, just non-terminating) for a
+  *worse* footgun — a forgotten `exit 0` at any of the 6 call sites would print the count
+  AND then fall through to the listing/summary code (broken output). The terminating
+  design eliminates that failure mode; the project already has terminating helpers
+  (`handle_upstream_operation` `exit 0`s internally). See Roast hardening §F-005.
 - **`local` is safe here** — this is a real function body (unlike the dispatcher
   top-level code), so `local` is legal under `set -euo pipefail`. The cerebrum's
   "local at top level is a fatal bash error" warning applies only to the dispatcher
@@ -136,7 +192,11 @@ run_count_mode() {
 ## Section 3 — Call-site transformation (6 dispatchers)
 
 The WHY comment (currently ~7 lines, duplicated 6×) moves into `run_count_mode`'s
-docblock (Section 2). Each call site keeps a one-line pointer.
+docblock (Section 2). Each call site keeps a one-line pointer. Note: `git-statusbase`'s
+extra comment about `all`/`all+untracked` dedup (one MM record) is **relocated, not
+dropped** — that rationale already lives in `count_files_with_status`'s header (lines
+14-15) and is summarized in the helper's docblock; a reviewer comparing diffs should read
+it as a move, not a deletion.
 
 ### 5 single-state dispatchers
 
@@ -202,27 +262,51 @@ transitively — no own copy to touch, exactly as #258 notes.)
 
 ### New test for #259
 
-In `test_hug-select-files.bats`, next to the `count_files_with_status` block:
+In `test_hug-select-files.bats`, next to the `count_files_with_status` block. Uses a
+fresh `mktemp -d` (not `cd /tmp`) so the "not a repo" precondition is deterministic even on
+machines where `/tmp` is versioned:
 
 ```bash
 @test "count_files_with_status: clean error outside a git repo (parity with list_*_files)" {
-  cd /tmp  # setup() cds into a repo; leave it for this assertion
+  local nonrepo
+  nonrepo=$(mktemp -d)   # fresh, guaranteed non-repo (setup() cds into a repo; leave it)
+  cd "$nonrepo"
   run count_files_with_status staged
   assert_failure
   assert_output --partial "Not in a git repository"
+  rm -rf "$nonrepo"
 }
 ```
 
-Convention matches `test_worktree_list.bats:142` (`cd /tmp; run git-wt; assert_failure;
-assert_output --partial "Not in a git repository"`). `check_git_repo` and `error` are in
-scope via `hug-git-kit` (already loaded at line 6 of the test file); `run` runs in a
-subshell that inherits the sourced function, and `error`→`exit 1` is contained there.
+`error` is in scope via `hug-common` (loaded at line 5 of the test file → `hug-output`);
+`check_git_repo` via `hug-git-kit` (line 6 → `hug-git-repo`). `run` runs in a subshell that
+inherits the sourced function, and `error`→`exit 1` is contained there (the same pattern
+`test_worktree_list.bats:142` relies on, though that test uses `cd /tmp`).
 
 ### Optional end-to-end test (only if it does not duplicate the lib test)
 
-A `hug sls -c` from `/tmp` asserting the same "Not in a git repository" message —
-confirms the wrapper + primitive compose end-to-end. Add **only** if it proves cheaper
-than it is duplicative; the lib test above is the load-bearing one for #259's acceptance.
+A `hug sls -c` from a fresh `mktemp -d` dir asserting the same "Not in a git repository"
+message — confirms the wrapper + primitive compose end-to-end. Add **only** if it proves
+cheaper than it is duplicative; the lib test above is the load-bearing one for #259's
+acceptance.
+
+### Doc-perimeter — `git-config/lib/README.md` (#259/#258 contract) — F-004
+
+`git-config/lib/README.md:202` documents `count_files_with_status` as a public library
+function (CLAUDE.md points readers here for library docs). It goes stale the moment this
+PR lands, so the change-set includes:
+
+- A new entry for `run_count_mode [--json] <state> [pathspec...]` next to the
+  `count_files_with_status` entry — describe it as the terminating dispatch wrapper that
+  encapsulates the mutual-exclusion guard + count + exit 0 (formerly duplicated across the
+  6 `sl*` dispatchers).
+- Amend the `count_files_with_status` entry to note it now enforces the repo precondition
+  internally (exits 1 with "Not in a git repository" outside a repo), matching the
+  `list_*_files` contract documented alongside it.
+
+User-facing command docs (`docs/commands/status-staging.md`) and `CHANGELOG.md` do **not**
+need updates — the user-facing `-c` behavior is unchanged; only the internal library
+surface changes.
 
 ### Verify commands
 
@@ -246,10 +330,16 @@ Mapped to the two issues:
         which stay green without modification).
 - **#259:**
   - [ ] `count_files_with_status` calls `check_git_repo` as its first line.
+  - [ ] `hug-select-files`'s `Depends on:` header (line 5) declares `hug-git-repo` (F-001).
   - [ ] `count_files_with_status` from a non-repo directory emits the HUG "Not in a git
-        repository" message, not raw git stderr (new lib test).
+        repository" message, not a silent `0`/silent crash (new lib test, `mktemp -d`).
   - [ ] No regression to in-repo `count_files_with_status` callers (existing lib tests
         green unchanged).
+- **Both (documentation perimeter):**
+  - [ ] `git-config/lib/README.md:202` gains a `run_count_mode` entry and an amended
+        `count_files_with_status` contract note (now enforces the repo precondition) (F-004).
+  - [ ] `hug-select-files`'s in-file header comment lists `run_count_mode` in its function
+        list (lines 6-9) and notes the repo precondition.
 
 ## Out of scope (YAGNI)
 
@@ -258,6 +348,19 @@ Mapped to the two issues:
   state to a pure helper.
 - Moving `check_git_repo` into `run_count_mode` only — rejected; does not satisfy #259's
   acceptance for direct library callers.
+- **Auto-sourcing `hug-git-repo` from `hug-select-files`** (F-001) — rejected on
+  VCS-boundary grounds: `hug-common` is symlinked into `hg-config/lib`, so
+  `hug-select-files` already loads in Mercurial contexts; defensively sourcing the
+  git-specific `hug-git-repo` (whose `check_git_repo` calls `git rev-parse`) would inject
+  git-only semantics into the hg path. Declaring the dep in the header (the chosen fix) is
+  sufficient because every real caller sources `hug-git-kit`.
+- **Adding `hug-git-repo` to `hug-common`'s `_hug_common_libs`** — rejected; same
+  VCS-boundary reason (shared bundle, git-specific dep).
+- **Moving `count_files_with_status`/`run_count_mode` into `hug-git-files`** (the
+  `hug-git-kit` bundle, for true co-load parity with `list_*_files`) — considered; would
+  remove a git-specific function from the shared `hug-common` bundle. Rejected as
+  scope-creep beyond #258/#259 (it would relocate the function and its tests and contradict
+  #258's stated location, "next to `count_files_with_status` in `hug-select-files`").
 - Refactoring the `sl*` JSON/listing paths (out of scope; only the `-c` dispatch is
   factored).
 - Touching `sl`/`sla` directly (they delegate via aliases).
@@ -270,9 +373,112 @@ Mapped to the two issues:
   unaffected (single state, no temp var).
 - **Terminating helper captured via `$(...)`:** if a future caller captures
   `run_count_mode` in command substitution, `exit 0` only exits the subshell and the
-  caller continues — a silent no-op. Mitigated by the docblock's TERMINATING note and by
-  the contract (callers invoke it as a statement inside `if $count_only; then ...; fi`).
+  caller continues — a **silent non-termination** (NOT a wrong number: the count is
+  captured correctly into the variable). The docblock's TERMINATING note flags this and
+  the contract is "call as a statement, never capture." This is preferred over a
+  non-terminating core + explicit `; exit 0` at each call site: that alternative re-introduces
+  a *worse* failure mode (a forgotten `exit 0` at any of the 6 sites would print the count
+  AND fall through to the listing/summary code). The terminating design makes the
+  failure-free path the default. (The two roast reports split on this: one rated it an
+  acceptable Minor, the other a Major recommending the non-terminating redesign; verified
+  analysis supports keeping terminating — see §F-005.)
 - **`--json` flag parsing vs. pathspecs starting with `--`:** a pathspec literally named
   `--json` would be mis-read as the flag. This is already broken upstream (the
   dispatchers' `case` collects anything not matching `--json`/`-c`/`-q` as a pathspec, so
   a real `--json` pathspec can't reach `run_count_mode` anyway). No new exposure.
+
+## Roast hardening (dual-voice resolution)
+
+This spec was roasted twice (`--spec` mode). Each finding was verified against ground
+truth in the worktree before acting; the two reviewers disagreed on one point (F-005),
+resolved by analysis rather than by majority. Findings and dispositions:
+
+### F-001 — Undeclared cross-module dependency (`check_git_repo`) — FIXED (declare-only)
+
+**Claim:** `count_files_with_status` lives in `hug-select-files` (loaded by the shared
+`hug-common`), but `check_git_repo` lives in `hug-git-repo` (loaded only by `hug-git-kit`).
+A `hug-common`-only caller would get `check_git_repo: command not found`.
+
+**Verified:**
+- `hug-common`'s `_hug_common_libs` (lines 80-93) lists `hug-output` (→`error`) and
+  `hug-select-files` (→`count_files_with_status`) but NOT `hug-git-repo`.
+- `hug-git-kit`'s loop (line 30) loads `hug-git-repo` (and does NOT load `hug-output`).
+- Sourcing `hug-common` alone: `error` ✓ defined, `count_files_with_status` ✓ defined,
+  `check_git_repo` ✗ NOT defined (empirically confirmed).
+- Root cause is a bundle asymmetry: `list_*_files` sits in `hug-git-files` (hug-git-kit
+  bundle → `hug-git-repo` co-loaded); `count_files_with_status` sits in `hug-select-files`
+  (hug-common bundle → `hug-git-repo` NOT co-loaded).
+
+**Fix:** Declare `hug-git-repo` in `hug-select-files`'s `Depends on:` header (line 5). All
+6 `sl*` dispatchers source `hug-git-kit`, so `check_git_repo` is available to every real
+caller and #259's acceptance holds.
+
+**Rejected alternatives (VCS-boundary):** defensively auto-sourcing `hug-git-repo` inside
+`hug-select-files`, and adding `hug-git-repo` to `hug-common`'s bundle — both rejected
+because `hug-config/lib/hug-common` is a **symlink** to `git-config/lib/hug-common`, so
+`hug-select-files` already loads in Mercurial contexts; injecting the git-specific
+`check_git_repo` (which calls `git rev-parse`) there is a VCS-boundary violation. (A third
+alternative — moving `count_files_with_status` into `hug-git-files` for true co-load parity
+— was rejected as scope-creep.)
+
+### F-002 — Factual error in the dependency-chain rationale — FIXED
+
+**Claim:** The spec said `hug-git-kit` aggregates `hug-output` (provides `error`). It does
+not. `error` reaches the dispatchers via `hug-common` (→ `hug-output`, loaded at
+`hug-common:83`); `check_git_repo` via `hug-git-kit` (→ `hug-git-repo`, loaded at
+`hug-git-kit:30`). Corrected in the Architecture section and the test section. (The roast's
+aside that `git-g` "sources only `hug-common`" was itself inaccurate — `git-g` sources
+`hug-git-repo` explicitly at line 11 — but the core finding holds.)
+
+### F-003 — Inaccurate "raw git error" description — FIXED
+
+**Claim:** The current non-repo behavior is not "a raw git error"; every `git` call in
+`count_files_with_status` is suffixed `2>/dev/null`, suppressing git's stderr.
+
+**Verified empirically from `/tmp`:**
+- Without `set -e`: `count_files_with_status staged` → `stdout=0`, `rc=0`, empty stderr
+  (silent wrong answer).
+- With `set -euo pipefail`: the `git status` pipeline returns 128, `set -e` kills the
+  shell, `2>/dev/null` ate the diagnostic → no output, no message, exit 128 (silent crash).
+
+Corrected throughout the spec. This **strengthens** #259: the bug is silent-wrong/silent-
+crash, worse than the cosmetic "raw git error" the issue body implied.
+
+### F-004 — Doc-perimeter omission (`git-config/lib/README.md`) — FIXED
+
+**Claim:** `git-config/lib/README.md:202` documents `count_files_with_status`; the
+change-set omitted it. Verified: the README lists the primitive with its state enum and
+NUL/Bash-floor guarantees. Added to the change-set (Section 4 "Doc-perimeter" + the
+Architecture diagram + acceptance): a new `run_count_mode` entry and an amended
+`count_files_with_status` contract note (now enforces the repo precondition).
+
+### F-005 — Terminating helper `exit 0` is context-dependent — ADDRESSED (kept, refuted redesign)
+
+**Claim:** `exit 0` inside a helper is a Bash footgun: terminating when called as a
+statement, non-terminating when captured in `$(...)`. The two roast reports disagreed
+(one: acceptable Minor; one: Major, recommending a non-terminating core + `; exit 0` at
+call sites).
+
+**Verified analysis (kept terminating):**
+- A `$(...)` capture of `run_count_mode` returns the **correct** count (the subshell's
+  stdout is captured); the caller simply does not terminate. That is a *benign*
+  non-termination, not a wrong number.
+- The non-terminating alternative trades this benign case for a *worse* footgun: a
+  forgotten `exit 0` at any of the 6 call sites would print the count AND fall through to
+  the listing/summary code (broken output). The terminating design makes the failure-free
+  path the default.
+- The project already has terminating helpers (`handle_upstream_operation` `exit 0`s
+  internally, per cerebrum).
+
+**Disposition:** kept the terminating helper; sharpened the docblock (the `$(...)`-capture
+behavior is now explicit) and the Risks section. The "always exits, never returns"
+contract is uniform (error→exit 1 on the mutex violation, exit 0 on success).
+
+### Minors — addressed
+- `cd /tmp` in the new test → `mktemp -d` (deterministic even if `/tmp` is versioned).
+- "Duplicated verbatim" → "duplicated near-verbatim" (statusbase has an extra branch +
+  dedup note).
+- Trimmed the docblock's "Why NUL-delimited + Bash-4.0-safe" pointer (duplicates the
+  primitive's own header, one `grep` away).
+- Noted the `git-statusbase` dedup comment is relocated (to the primitive's header /
+  helper docblock), not dropped — so a reviewer reads the diff as a move.

--- a/docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md
+++ b/docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md
@@ -81,7 +81,7 @@ for free from its bundle; `count_files_with_status` does not — its bundle (`hu
 doesn't carry `hug-git-repo`. The fix is to **declare** `hug-git-repo` in `hug-select-files`'s
 `Depends on:` header (line 5) so the new dependency is honest and discoverable, matching the
 codebase convention (modules declare deps; the caller sources them — `git-g` itself sources
-`hug-git-repo` explicitly at line 11 for exactly this reason). We do **not** auto-source
+`hug-git-repo` explicitly at line 13 for exactly this reason). We do **not** auto-source
 `hug-git-repo` from `hug-select-files`: `hug-common` is symlinked into `hg-config/lib`, so
 `hug-select-files` already loads in Mercurial contexts, and defensively sourcing the
 git-specific `hug-git-repo` (whose `check_git_repo` calls `git rev-parse`) there would
@@ -124,7 +124,7 @@ any existing in-repo caller — the entire `sl* -c` test suite cds into a repo f
 dispatchers load via `hug-git-kit`. A caller that sources only `hug-common` (which loads
 `hug-select-files` but not `hug-git-repo`) must source `hug-git-repo` itself, as the
 `Depends on:` header now declares — the same contract every other module in this codebase
-uses (callers source declared deps; `git-g` does this explicitly at line 11). #259's
+uses (callers source declared deps; `git-g` does this explicitly at line 13). #259's
 acceptance is met for every real caller.
 
 ## Section 2 — `run_count_mode` wrapper (#258)
@@ -147,8 +147,10 @@ Add directly above `count_files_with_status` in `hug-select-files`:
 #   NEVER returns — a caller running it inside `if $count_only; then ...; fi` never
 #   reaches code below the block. Pass `--json` with `${json_output:+--json}` so the
 #   caller stays a single line. Do NOT capture this in $(...) : the subshell exit is
-#   contained, the count is captured correctly, but the caller does NOT terminate
-#   (silent non-termination) — call it as a statement, never as a substitution.
+#   contained and the count is captured correctly, but the caller does NOT terminate
+#   — in the dispatchers, execution falls through to the listing/summary code and
+#   prints BOTH the (captured) count AND the listing (broken output). Call it as a
+#   statement, never as a substitution.
 run_count_mode() {
   local json=false
   [[ "${1:-}" == --json ]] && { json=true; shift; }
@@ -271,17 +273,22 @@ machines where `/tmp` is versioned:
   local nonrepo
   nonrepo=$(mktemp -d)   # fresh, guaranteed non-repo (setup() cds into a repo; leave it)
   cd "$nonrepo"
-  run count_files_with_status staged
+  run --separate-stderr count_files_with_status staged
   assert_failure
-  assert_output --partial "Not in a git repository"
+  [[ -z "$output" ]]                                  # stdout clean: no leaked count (the old silent-0)
+  [[ "$stderr" == *"Not in a git repository"* ]]      # stderr carries the clean HUG message
   rm -rf "$nonrepo"
 }
 ```
 
-`error` is in scope via `hug-common` (loaded at line 5 of the test file → `hug-output`);
-`check_git_repo` via `hug-git-kit` (line 6 → `hug-git-repo`). `run` runs in a subshell that
-inherits the sourced function, and `error`→`exit 1` is contained there (the same pattern
-`test_worktree_list.bats:142` relies on, though that test uses `cd /tmp`).
+Uses `run --separate-stderr` (BATS ≥1.6; the repo already uses it at
+`test_status_staging.bats:1947`) so the two halves of the acceptance — "no silent `0` on
+stdout" and "the clean message on stderr" — are pinned **independently**. (`gum_log`
+writes `>&2`, so the message lands on stderr; `check_git_repo` is the first executable line
+and `error`→`exit 1` runs before any `printf '%d\n'`, so stdout is structurally empty on
+the error path.) `error` is in scope via `hug-common` (line 5 → `hug-output`);
+`check_git_repo` via `hug-git-kit` (line 6 → `hug-git-repo`); `run` runs in a subshell that
+inherits the sourced function and contains the `error`→`exit 1`.
 
 ### Optional end-to-end test (only if it does not duplicate the lib test)
 
@@ -364,6 +371,12 @@ Mapped to the two issues:
 - Refactoring the `sl*` JSON/listing paths (out of scope; only the `-c` dispatch is
   factored).
 - Touching `sl`/`sla` directly (they delegate via aliases).
+- **`--json`/pathspec arg-parsing hardening** (roast MINOR 4) — `run_count_mode`'s
+  `--json` detection is position-only (`$1`), and the 6 dispatcher `case` blocks don't
+  honor `--` as a pathspec separator (a pre-existing limitation: a pathspec literally named
+  `--json` is consumed as the flag before it can reach the count logic). Both are
+  pre-existing and independent of this refactor; tracked as
+  [elifarley/hug-scm#260](https://github.com/elifarley/hug-scm/issues/260) (separate PR).
 
 ## Risks
 
@@ -373,15 +386,17 @@ Mapped to the two issues:
   unaffected (single state, no temp var).
 - **Terminating helper captured via `$(...)`:** if a future caller captures
   `run_count_mode` in command substitution, `exit 0` only exits the subshell and the
-  caller continues — a **silent non-termination** (NOT a wrong number: the count is
-  captured correctly into the variable). The docblock's TERMINATING note flags this and
-  the contract is "call as a statement, never capture." This is preferred over a
-  non-terminating core + explicit `; exit 0` at each call site: that alternative re-introduces
-  a *worse* failure mode (a forgotten `exit 0` at any of the 6 sites would print the count
-  AND fall through to the listing/summary code). The terminating design makes the
-  failure-free path the default. (The two roast reports split on this: one rated it an
-  acceptable Minor, the other a Major recommending the non-terminating redesign; verified
-  analysis supports keeping terminating — see §F-005.)
+  caller continues — the count is captured correctly (NOT a wrong number), but the caller
+  does not terminate, so in the dispatchers execution falls through to the
+  listing/summary code and prints BOTH the count AND the listing (broken output — the
+  same broken-output shape as a forgotten `exit 0`, but reachable only by violating the
+  "never capture" contract, i.e. 1 chance vs the non-terminating alternative's 6
+  call-sites). The docblock flags this and the contract is "call as a statement, never
+  capture." The terminating design is preferred because it makes the failure-free path the
+  default (0 forgotten-`exit 0` sites); the non-terminating alternative has 6. (The two
+  roast reports split on this: one rated it an acceptable Minor, the other a Major
+  recommending the non-terminating redesign; verified analysis supports keeping
+  terminating — see §F-005.)
 - **`--json` flag parsing vs. pathspecs starting with `--`:** a pathspec literally named
   `--json` would be mis-read as the flag. This is already broken upstream (the
   dispatchers' `case` collects anything not matching `--json`/`-c`/`-q` as a pathspec, so
@@ -428,7 +443,7 @@ not. `error` reaches the dispatchers via `hug-common` (→ `hug-output`, loaded 
 `hug-common:83`); `check_git_repo` via `hug-git-kit` (→ `hug-git-repo`, loaded at
 `hug-git-kit:30`). Corrected in the Architecture section and the test section. (The roast's
 aside that `git-g` "sources only `hug-common`" was itself inaccurate — `git-g` sources
-`hug-git-repo` explicitly at line 11 — but the core finding holds.)
+`hug-git-repo` explicitly at line 13 — but the core finding holds.)
 
 ### F-003 — Inaccurate "raw git error" description — FIXED
 
@@ -482,3 +497,22 @@ contract is uniform (error→exit 1 on the mutex violation, exit 0 on success).
   primitive's own header, one `grep` away).
 - Noted the `git-statusbase` dedup comment is relocated (to the primitive's header /
   helper docblock), not dropped — so a reviewer reads the diff as a move.
+
+### Re-roast (round 3) — no CRITICAL/MAJOR; four MINORs addressed
+
+A third `--spec` roast re-verified every load-bearing claim (F-001–F-005 all survived) and
+returned **no CRITICAL or MAJOR issues** — the spec was ready to proceed to the plan. Four
+MINORs, all addressed in this commit:
+
+- **M1 (test polish):** the #259 test now uses `run --separate-stderr` and asserts stdout
+  is empty (`[[ -z "$output" ]]`) AND stderr carries the message — pinning both halves of
+  the acceptance ("no silent `0`" + "clean message") independently.
+- **M2 (F-005 wording):** the `$(...)`-capture wording now states the downstream consequence
+  explicitly — the count is captured correctly but the caller does not terminate, so in the
+  dispatchers execution falls through to the listing code (broken output: count + listing).
+  The "1 contract-violation vs 6 forgotten-`exit 0` sites" symmetry is now explicit.
+- **M3 (factual nit):** `git-g` sources `hug-git-repo` at line **13** (line 11 is
+  `hug-git-gc`); the spec's "line 11" aside was corrected.
+- **M4 (arg-parsing follow-up):** the position-only `--json` detection in `run_count_mode`
+  and the pre-existing `--json`-as-pathspec limitation in the dispatcher `case` blocks are
+  out of scope here and tracked as [elifarley/hug-scm#260](https://github.com/elifarley/hug-scm/issues/260).

--- a/git-config/bin/git-slc
+++ b/git-config/bin/git-slc
@@ -92,18 +92,15 @@ if [[ ${#pathspecs[@]} -gt 0 ]]; then
   list_opts+=("${pathspecs[@]}")
 fi
 
-# Count mode: print the number of matching files (the grep -c of listings).
-# NUL-safe + Bash-4.0-safe via count_files_with_status (hug-select-files):
-# counts git's NUL-delimited records, so newline-containing filenames count
-# once, and no `local -n` nameref (Bash 4.3+) is reached. The count is the
-# whole answer: it suppresses the trailing summary and is mutually exclusive
-# with --json (like `hug wtl`'s --json --path-only error).
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+# --json passed only when $json_output is true (the codebase stores booleans as
+# true/false strings; ${json_output:+--json} would ALWAYS expand — see run_count_mode).
 if $count_only; then
   if $json_output; then
-    error "-c/--count and --json are mutually exclusive"
+    run_count_mode --json conflicted "${pathspecs[@]}"
+  else
+    run_count_mode conflicted "${pathspecs[@]}"
   fi
-  count_files_with_status conflicted "${pathspecs[@]}"
-  exit 0
 fi
 
 # JSON output mode

--- a/git-config/bin/git-sli
+++ b/git-config/bin/git-sli
@@ -55,18 +55,15 @@ if [[ ${#pathspecs[@]} -gt 0 ]]; then
   list_opts+=("${pathspecs[@]}")
 fi
 
-# Count mode: print the number of matching files (the grep -c of listings).
-# NUL-safe + Bash-4.0-safe via count_files_with_status (hug-select-files):
-# counts git's NUL-delimited records, so newline-containing filenames count
-# once, and no `local -n` nameref (Bash 4.3+) is reached. The count is the
-# whole answer: it suppresses the trailing summary and is mutually exclusive
-# with --json (like `hug wtl`'s --json --path-only error).
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+# --json passed only when $json_output is true (the codebase stores booleans as
+# true/false strings; ${json_output:+--json} would ALWAYS expand — see run_count_mode).
 if $count_only; then
   if $json_output; then
-    error "-c/--count and --json are mutually exclusive"
+    run_count_mode --json ignored "${pathspecs[@]}"
+  else
+    run_count_mode ignored "${pathspecs[@]}"
   fi
-  count_files_with_status ignored "${pathspecs[@]}"
-  exit 0
 fi
 
 # JSON output mode

--- a/git-config/bin/git-slk
+++ b/git-config/bin/git-slk
@@ -55,18 +55,15 @@ if [[ ${#pathspecs[@]} -gt 0 ]]; then
   list_opts+=("${pathspecs[@]}")
 fi
 
-# Count mode: print the number of matching files (the grep -c of listings).
-# NUL-safe + Bash-4.0-safe via count_files_with_status (hug-select-files):
-# counts git's NUL-delimited records, so newline-containing filenames count
-# once, and no `local -n` nameref (Bash 4.3+) is reached. The count is the
-# whole answer: it suppresses the trailing summary and is mutually exclusive
-# with --json (like `hug wtl`'s --json --path-only error).
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+# --json passed only when $json_output is true (the codebase stores booleans as
+# true/false strings; ${json_output:+--json} would ALWAYS expand — see run_count_mode).
 if $count_only; then
   if $json_output; then
-    error "-c/--count and --json are mutually exclusive"
+    run_count_mode --json untracked "${pathspecs[@]}"
+  else
+    run_count_mode untracked "${pathspecs[@]}"
   fi
-  count_files_with_status untracked "${pathspecs[@]}"
-  exit 0
 fi
 
 # JSON output mode

--- a/git-config/bin/git-sls
+++ b/git-config/bin/git-sls
@@ -50,18 +50,15 @@ if [[ ${#pathspecs[@]} -gt 0 ]]; then
   list_opts+=("${pathspecs[@]}")
 fi
 
-# Count mode: print the number of matching files (the grep -c of listings).
-# NUL-safe + Bash-4.0-safe via count_files_with_status (hug-select-files):
-# counts git's NUL-delimited records, so newline-containing filenames count
-# once, and no `local -n` nameref (Bash 4.3+) is reached. The count is the
-# whole answer: it suppresses the trailing summary and is mutually exclusive
-# with --json (like `hug wtl`'s --json --path-only error).
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+# --json passed only when $json_output is true (the codebase stores booleans as
+# true/false strings; ${json_output:+--json} would ALWAYS expand — see run_count_mode).
 if $count_only; then
   if $json_output; then
-    error "-c/--count and --json are mutually exclusive"
+    run_count_mode --json staged "${pathspecs[@]}"
+  else
+    run_count_mode staged "${pathspecs[@]}"
   fi
-  count_files_with_status staged "${pathspecs[@]}"
-  exit 0
 fi
 
 # JSON output mode

--- a/git-config/bin/git-slu
+++ b/git-config/bin/git-slu
@@ -50,18 +50,15 @@ if [[ ${#pathspecs[@]} -gt 0 ]]; then
   list_opts+=("${pathspecs[@]}")
 fi
 
-# Count mode: print the number of matching files (the grep -c of listings).
-# NUL-safe + Bash-4.0-safe via count_files_with_status (hug-select-files):
-# counts git's NUL-delimited records, so newline-containing filenames count
-# once, and no `local -n` nameref (Bash 4.3+) is reached. The count is the
-# whole answer: it suppresses the trailing summary and is mutually exclusive
-# with --json (like `hug wtl`'s --json --path-only error).
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+# --json passed only when $json_output is true (the codebase stores booleans as
+# true/false strings; ${json_output:+--json} would ALWAYS expand — see run_count_mode).
 if $count_only; then
   if $json_output; then
-    error "-c/--count and --json are mutually exclusive"
+    run_count_mode --json unstaged "${pathspecs[@]}"
+  else
+    run_count_mode unstaged "${pathspecs[@]}"
   fi
-  count_files_with_status unstaged "${pathspecs[@]}"
-  exit 0
 fi
 
 # JSON output mode

--- a/git-config/bin/git-statusbase
+++ b/git-config/bin/git-statusbase
@@ -63,23 +63,16 @@ fi
 
 # TODO list files sorted by reverse status text (so that `S:*` files appear last, closer to the cursor line after the command has finished printing a lot of lines. The second field to sort should be the file path.
 
-# Count mode: print the number of matching files (the grep -c of listings).
-# NUL-safe + Bash-4.0-safe via count_files_with_status (hug-select-files):
-# counts git's NUL-delimited records, so newline-containing filenames count
-# once, and no `local -n` nameref (Bash 4.3+) is reached. The count is the
-# whole answer: it suppresses the trailing summary and is mutually exclusive
-# with --json (like `hug wtl`'s --json --path-only error). all/all+untracked
-# dedup a file that is both staged and unstaged (one MM record in porcelain).
+# Count mode: -c/--count dispatch (see run_count_mode in hug-select-files).
+# --json passed only when $json_output is true (the codebase stores booleans as
+# true/false strings; ${json_output:+--json} would ALWAYS expand — see run_count_mode).
 if $count_only; then
+  if $include_untracked; then _slc_state=all+untracked; else _slc_state=all; fi
   if $json_output; then
-    error "-c/--count and --json are mutually exclusive"
-  fi
-  if $include_untracked; then
-    count_files_with_status all+untracked "${pathspecs[@]}"
+    run_count_mode --json "$_slc_state" "${pathspecs[@]}"
   else
-    count_files_with_status all "${pathspecs[@]}"
+    run_count_mode "$_slc_state" "${pathspecs[@]}"
   fi
-  exit 0
 fi
 
 # JSON output mode

--- a/git-config/lib/README.md
+++ b/git-config/lib/README.md
@@ -204,6 +204,9 @@ Git-specific JSON output helpers (uses hug-json).
   - Prints an integer (0 when none, exit 0). NUL-safe (newline filenames count once) and Bash 4.0-safe (no nameref).
   - `all`/`all+untracked` dedup via `git status --porcelain -z` (a file staged AND unstaged counts once)
   - Enforces the repo precondition internally (`check_git_repo`): exits 1 with "Not in a git repository" when called outside a repo (parity with `list_*_files`)
+- `run_count_mode [--json] <state> [pathspec...]` - Terminating wrapper for the sl* `-c/--count` dispatch
+  - Encapsulates the mutual-exclusion guard + `count_files_with_status` call + `exit 0` (formerly duplicated across the 6 `sl*` dispatchers)
+  - `--json` is mutually exclusive with `-c` (errors and exits); the function ALWAYS exits (never returns) — call it as a statement, never in `$(...)`
 
 **JSON Design Philosophy:**
 - Pure Bash for portability and dependency-free operation

--- a/git-config/lib/README.md
+++ b/git-config/lib/README.md
@@ -203,6 +203,7 @@ Git-specific JSON output helpers (uses hug-json).
   - `<state>`: `staged`|`unstaged`|`untracked`|`ignored`|`conflicted`|`all`|`all+untracked`
   - Prints an integer (0 when none, exit 0). NUL-safe (newline filenames count once) and Bash 4.0-safe (no nameref).
   - `all`/`all+untracked` dedup via `git status --porcelain -z` (a file staged AND unstaged counts once)
+  - Enforces the repo precondition internally (`check_git_repo`): exits 1 with "Not in a git repository" when called outside a repo (parity with `list_*_files`)
 
 **JSON Design Philosophy:**
 - Pure Bash for portability and dependency-free operation

--- a/git-config/lib/hug-select-files
+++ b/git-config/lib/hug-select-files
@@ -39,8 +39,11 @@
 #   (3) exit 0.
 # TERMINATING: calls `exit 0` (and `error`->exit 1 on the --json violation), so it
 #   NEVER returns -- a caller running it inside `if $count_only; then ...; fi` never
-#   reaches code below the block. Pass `--json` with `${json_output:+--json}` so the
-#   caller stays a single line. Do NOT capture this in $(...) : the subshell exit is
+#   reaches code below the block. Callers pass `--json` only when their json flag is
+#   true, e.g. `if $json_output; then run_count_mode --json <state> ...; else
+#   run_count_mode <state> ...; fi`. Do NOT use ${json_output:+--json}: hug stores
+#   booleans as the strings true/false, so :+ fires on the non-empty "false" too and
+#   would ALWAYS pass --json. Do NOT capture this in $(...) : the subshell exit is
 #   contained and the count is captured correctly, but the caller does NOT terminate
 #   -- in the dispatchers, execution falls through to the listing/summary code and
 #   prints BOTH the (captured) count AND the listing (broken output). Call it as a

--- a/git-config/lib/hug-select-files
+++ b/git-config/lib/hug-select-files
@@ -2,11 +2,11 @@
 # Library: HUG interactive file selection
 #
 # Implements gum-powered file selection with git status annotations.
-# Depends on: hug-gum, hug-output, hug-terminal, hug-git-files (for list_* functions), hug-git-priorities.
+# Depends on: hug-gum, hug-output, hug-terminal, hug-git-files (for list_* functions), hug-git-priorities, hug-git-repo (for check_git_repo, used by count_files_with_status).
 # Functions:
 #   - list_files_with_status: list staged/unstaged/untracked files with color-coded status (non-interactive).
 #   - select_files_with_status: filter staged/unstaged/untracked files interactively.
-#   - count_files_with_status: count files by state (NUL-safe, scriptable; the sl* `-c` engine).
+#   - count_files_with_status: count files by state (NUL-safe, scriptable; the sl* `-c` engine; enforces the repo precondition via check_git_repo).
 
 # Count files in a given state — the grep -c of file listings.
 # Usage: count_files_with_status <state> [pathspec...]
@@ -25,6 +25,7 @@
 #     which emits ONE record per file (MM for a file both staged and unstaged),
 #     so the count is deduplicated by construction.
 count_files_with_status() {
+  check_git_repo   # Parity with list_*_files: clean HUG error from any context (#259)
   local state="$1"
   shift
   local -a pathspecs=("$@")

--- a/git-config/lib/hug-select-files
+++ b/git-config/lib/hug-select-files
@@ -7,6 +7,7 @@
 #   - list_files_with_status: list staged/unstaged/untracked files with color-coded status (non-interactive).
 #   - select_files_with_status: filter staged/unstaged/untracked files interactively.
 #   - count_files_with_status: count files by state (NUL-safe, scriptable; the sl* `-c` engine; enforces the repo precondition via check_git_repo).
+#   - run_count_mode: terminating wrapper for the sl* -c/--count dispatch (mutual-exclusion guard + count + exit 0).
 
 # Count files in a given state — the grep -c of file listings.
 # Usage: count_files_with_status <state> [pathspec...]
@@ -24,6 +25,38 @@
 #   - Multi-state counts (all/all+untracked) use `git status --porcelain -z`,
 #     which emits ONE record per file (MM for a file both staged and unstaged),
 #     so the count is deduplicated by construction.
+
+# run_count_mode — terminating wrapper for the sl* -c/--count dispatch.
+# Usage: run_count_mode [--json] <state> [pathspec...]
+#   <state>: the count_files_with_status enum (staged|unstaged|untracked|ignored|
+#           conflicted|all|all+untracked).
+# Encapsulates the -c dispatch previously duplicated (near-verbatim) across the 6 sl*
+# scripts (git-sls/slu/slk/sli/slc/statusbase):
+#   (1) --json is mutually exclusive with -c -> error + exit (like hug wtl's
+#       --json --path-only error),
+#   (2) delegate to count_files_with_status (which itself enforces the repo
+#       precondition -- #259),
+#   (3) exit 0.
+# TERMINATING: calls `exit 0` (and `error`->exit 1 on the --json violation), so it
+#   NEVER returns -- a caller running it inside `if $count_only; then ...; fi` never
+#   reaches code below the block. Pass `--json` with `${json_output:+--json}` so the
+#   caller stays a single line. Do NOT capture this in $(...) : the subshell exit is
+#   contained and the count is captured correctly, but the caller does NOT terminate
+#   -- in the dispatchers, execution falls through to the listing/summary code and
+#   prints BOTH the (captured) count AND the listing (broken output). Call it as a
+#   statement, never as a substitution.
+run_count_mode() {
+  local json=false
+  [[ "${1:-}" == --json ]] && { json=true; shift; }
+  local state="$1"; shift
+  local -a pathspecs=("$@")
+  if $json; then
+    error "-c/--count and --json are mutually exclusive"
+  fi
+  count_files_with_status "$state" "${pathspecs[@]}"
+  exit 0
+}
+
 count_files_with_status() {
   check_git_repo   # Parity with list_*_files: clean HUG error from any context (#259)
   local state="$1"

--- a/git-config/lib/hug-select-files
+++ b/git-config/lib/hug-select-files
@@ -51,7 +51,7 @@
 run_count_mode() {
   local json=false
   [[ "${1:-}" == --json ]] && { json=true; shift; }
-  local state="$1"; shift
+  local state="${1:?run_count_mode: <state> required}"; shift
   local -a pathspecs=("$@")
   if $json; then
     error "-c/--count and --json are mutually exclusive"

--- a/tests/lib/test_hug-select-files.bats
+++ b/tests/lib/test_hug-select-files.bats
@@ -7,6 +7,10 @@ load '../../git-config/lib/hug-git-kit'
 load '../../git-config/lib/hug-gum'
 load '../../git-config/lib/hug-select-files'
 
+# run --separate-stderr is used below (bats >= 1.5) to assert stdout/stderr
+# independently for the non-repo parity test (#259).
+bats_require_minimum_version 1.5.0
+
 # Helper to create test repo with files in subdirectories
 create_test_repo_for_selection() {
   local test_repo
@@ -874,6 +878,17 @@ create_merge_conflict() {
 
   [[ "$(count_files_with_status untracked)" == "2" ]]
   [[ "$(count_files_with_status all+untracked)" == "2" ]]
+}
+
+@test "count_files_with_status: clean error outside a git repo (parity with list_*_files)" {
+  local nonrepo
+  nonrepo=$(mktemp -d)   # fresh, guaranteed non-repo (setup() cds into a repo; leave it)
+  cd "$nonrepo"
+  run --separate-stderr count_files_with_status staged
+  assert_failure
+  [[ -z "$output" ]]                                  # stdout clean: no leaked count (the old silent-0)
+  [[ "$stderr" == *"Not in a git repository"* ]]      # stderr carries the clean HUG message
+  rm -rf "$nonrepo"
 }
 
 @test "count_files_with_status: conflicted counts unmerged files" {

--- a/tests/lib/test_hug-select-files.bats
+++ b/tests/lib/test_hug-select-files.bats
@@ -891,6 +891,33 @@ create_merge_conflict() {
   rm -rf "$nonrepo"
 }
 
+@test "run_count_mode: prints the count and exits 0 (terminating wrapper)" {
+  local repo
+  repo=$(create_test_repo)
+  cd "$repo"
+  echo "staged" > staged.txt
+  git add staged.txt
+
+  # TERMINATING: run in a subshell via `run`; prints the count, exit 0.
+  run --separate-stderr run_count_mode staged
+  assert_success
+  assert_output "1"
+  [[ -z "$stderr" ]]
+}
+
+@test "run_count_mode: --json and -c are mutually exclusive" {
+  local repo
+  repo=$(create_test_repo)
+  cd "$repo"
+  echo "staged" > staged.txt
+  git add staged.txt
+
+  run --separate-stderr run_count_mode --json staged
+  assert_failure
+  [[ "$stderr" == *"mutually exclusive"* ]]
+  [[ -z "$output" ]]   # no count printed on the mutex-violation path
+}
+
 @test "count_files_with_status: conflicted counts unmerged files" {
   local repo
   repo=$(create_test_repo)


### PR DESCRIPTION
✅ Collapse the duplicated -c/--count dispatch across the 6 sl* dispatchers into one run_count_mode helper, and make count_files_with_status check the repo (parity with list_*_files). Removes a silent wrong answer: from a non-repo dir, sl* -c returned 0 (exit 0) with no diagnostic, because every git call is 2>/dev/null.

🟢 Low risk: behavior-preserving by construction (run_count_mode encapsulates exactly the old mutex-guard + count + exit 0); 16 sl* -c unit tests + 60 lib tests pin the contract and stay green unchanged.

More context: https://github.com/elifarley/hug-scm/issues/258

Closes elifarley/hug-scm#258
Closes elifarley/hug-scm#259

<details><summary>Details — what changed, the TDD-caught defect, tests, follow-ups</summary>

Two stacked edits to git-config/lib/hug-select-files, then wire the 6 dispatchers.

#259 — count_files_with_status (the sl* -c engine) now calls check_git_repo as its first line. Outside a repo it emits the clean HUG "Not in a git repository" message (exit 1) instead of a silent 0/crash, matching every list_*_files. The new hug-git-repo dependency is declared in the module's Depends on: header (declared, not auto-sourced: hug-common is symlinked into hg-config, so hug-select-files already loads in Mercurial contexts; auto-sourcing the git-specific hug-git-repo there would be a VCS-boundary violation). All 6 sl* dispatchers source hug-git-kit, which loads hug-git-repo, so check_git_repo is available to every real caller.

#258 — added run_count_mode [--json] <state> [pathspec...], directly above count_files_with_status. It owns the --json mutual-exclusion error (exit 1), the delegation to count_files_with_status, and exit 0. It is TERMINATING (always exits, never returns). The 6 dispatchers (git-sls/slu/slk/sli/slc/statusbase) each replace their ~13-line duplicated count block with a run_count_mode call. sl/sla delegate to git-statusbase via .gitconfig aliases, covered transitively.

⚠️ TDD-caught defect (missed by 3 spec-roast rounds): the spec/plan originally prescribed passing --json via ${json_output:+--json}. That idiom is BROKEN here — hug stores booleans as the strings true/false, so ${var:+word} fires on the non-empty "false" too and ALWAYS yields --json, making every sl* -c error as mutually exclusive. Caught when all 16 sl* -c tests failed on the first run. Corrected to the two-branch if $json_output; then run_count_mode --json ...; else run_count_mode ...; fi idiom (the codebase's established conditional-flag pattern, e.g. git-statusbase's own if $include_untracked). The run_count_mode docblock carries a "Do NOT use ${json_output:+--json}" warning with the rationale. git-statusbase uses a scratch _slc_state var to select all+untracked vs all (no top-level local, fatal under set -euo pipefail).

Tests: existing sl* -c unit tests (slc -c --json mutex, slk -c NUL-safety, slu -c pathspec, sls/sli/sl/sla -c) pin the contract end-to-end and stay green. New lib tests: count_files_with_status non-repo clean error (run --separate-stderr); run_count_mode count + mutex. 60/60 lib, 162/162 status-staging unit, sanitize clean. The only full-suite failures are documented local-only flakes (global core.hooksPath / core.excludesFile / symlinked HUG_HOME), green in CI.

Design spec: docs/superpowers/specs/2026-08-07-sl-count-engine-refactor-design.md (roast-clean after 3 rounds + the TDD-caught idiom correction). Plan: docs/superpowers/plans/2026-08-08-sl-count-engine-refactor.md.

</details>

🔁 Suggested follow-up: elifarley/hug-scm#260 — harden --json/pathspec arg parsing in run_count_mode + the dispatcher case blocks (pre-existing, independent of this refactor).
